### PR TITLE
Add copyright headers

### DIFF
--- a/viz/narrations/review/src/components/CollectionView.jsx
+++ b/viz/narrations/review/src/components/CollectionView.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React, { useState } from "react";
 import { Redirect } from "react-router-dom";
 import { useMephistoReview } from "mephisto-review-hook";

--- a/viz/narrations/review/src/components/ErrorPane.js
+++ b/viz/narrations/review/src/components/ErrorPane.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { Button, Icon } from "@blueprintjs/core";
 

--- a/viz/narrations/review/src/components/ItemView.jsx
+++ b/viz/narrations/review/src/components/ItemView.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { useMephistoReview } from "mephisto-review-hook";
 import { useParams, useHistory, Link } from "react-router-dom";

--- a/viz/narrations/review/src/components/pagination/Pagination.css
+++ b/viz/narrations/review/src/components/pagination/Pagination.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 .pagination {
   padding: 12px 0px;
 }

--- a/viz/narrations/review/src/components/pagination/Pagination.jsx
+++ b/viz/narrations/review/src/components/pagination/Pagination.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { Button, Icon, Intent } from "@blueprintjs/core";
 import "./Pagination.css";

--- a/viz/narrations/review/src/components/pagination/index.js
+++ b/viz/narrations/review/src/components/pagination/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import Pagination from "./Pagination";
 
 export { Pagination };

--- a/viz/narrations/review/src/config.js
+++ b/viz/narrations/review/src/config.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 const config = {
   /*
     The port that useMephistoReview() in the browser will connect to the

--- a/viz/narrations/review/src/custom/NarrationsApp.css
+++ b/viz/narrations/review/src/custom/NarrationsApp.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 .segment {
 }
 .segment-wrapper {

--- a/viz/narrations/review/src/custom/NarrationsApp.js
+++ b/viz/narrations/review/src/custom/NarrationsApp.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import ReactPlayer from "react-player"; /* dependency */
 import { getHostname } from "../utils";

--- a/viz/narrations/review/src/custom/NarrationsItem.js
+++ b/viz/narrations/review/src/custom/NarrationsItem.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import NarrationsApp from "./NarrationsApp";
 

--- a/viz/narrations/review/src/custom/NarrationsThumbnail.js
+++ b/viz/narrations/review/src/custom/NarrationsThumbnail.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { H6, Card, Elevation } from "@blueprintjs/core";
 import { getHostname } from "../utils";

--- a/viz/narrations/review/src/index.css
+++ b/viz/narrations/review/src/index.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",

--- a/viz/narrations/review/src/index.js
+++ b/viz/narrations/review/src/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";

--- a/viz/narrations/review/src/renderers/GridCollection/GridCollection.css
+++ b/viz/narrations/review/src/renderers/GridCollection/GridCollection.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 .default-collection-renderer-container {
   display: grid;
   grid-template-rows: auto;

--- a/viz/narrations/review/src/renderers/GridCollection/GridCollection.jsx
+++ b/viz/narrations/review/src/renderers/GridCollection/GridCollection.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { Link } from "react-router-dom";
 import { JSONItem } from "../JSONItem";

--- a/viz/narrations/review/src/renderers/GridCollection/index.js
+++ b/viz/narrations/review/src/renderers/GridCollection/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import { GridCollection } from "./GridCollection";
 
 export { GridCollection };

--- a/viz/narrations/review/src/renderers/JSONItem/JSONItem.css
+++ b/viz/narrations/review/src/renderers/JSONItem/JSONItem.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 .json-item-renderer {
   margin: auto 0px;
   height: 100%;

--- a/viz/narrations/review/src/renderers/JSONItem/JSONItem.jsx
+++ b/viz/narrations/review/src/renderers/JSONItem/JSONItem.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React, { useRef, useEffect, useState } from "react";
 import { H6, Card, Elevation } from "@blueprintjs/core";
 import "./JSONItem.css";

--- a/viz/narrations/review/src/renderers/JSONItem/index.js
+++ b/viz/narrations/review/src/renderers/JSONItem/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import { JSONItem } from "./JSONItem";
 
 export { JSONItem };

--- a/viz/narrations/review/src/renderers/ListCollection/ListCollection.css
+++ b/viz/narrations/review/src/renderers/ListCollection/ListCollection.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 .list-view-renderer-container {
   width: 75vw;
   margin: 12px 0px 0px 0px;

--- a/viz/narrations/review/src/renderers/ListCollection/ListCollection.jsx
+++ b/viz/narrations/review/src/renderers/ListCollection/ListCollection.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { Link } from "react-router-dom";
 import { Card, Divider } from "@blueprintjs/core";

--- a/viz/narrations/review/src/renderers/ListCollection/ListItem.jsx
+++ b/viz/narrations/review/src/renderers/ListCollection/ListItem.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import { H6 } from "@blueprintjs/core";
 

--- a/viz/narrations/review/src/renderers/ListCollection/index.js
+++ b/viz/narrations/review/src/renderers/ListCollection/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import ListItem from "./ListItem";
 import ListCollection from "./ListCollection";
 

--- a/viz/narrations/review/src/renderers/WordCloudItem/WordCloud.css
+++ b/viz/narrations/review/src/renderers/WordCloudItem/WordCloud.css
@@ -1,3 +1,5 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved. */
+
 .word-cloud {
   text-align: center;
   justify-content: center;

--- a/viz/narrations/review/src/renderers/WordCloudItem/WordCloud.jsx
+++ b/viz/narrations/review/src/renderers/WordCloudItem/WordCloud.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React from "react";
 import "./WordCloud.css";
 

--- a/viz/narrations/review/src/renderers/WordCloudItem/WordCloudItem.jsx
+++ b/viz/narrations/review/src/renderers/WordCloudItem/WordCloudItem.jsx
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import React, { useRef, useEffect, useState } from "react";
 import { H6, Card, Elevation } from "@blueprintjs/core";
 import WordCloud from "./WordCloud";

--- a/viz/narrations/review/src/renderers/WordCloudItem/index.js
+++ b/viz/narrations/review/src/renderers/WordCloudItem/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import WordCloud from "./WordCloud";
 import WordCloudItem from "./WordCloudItem";
 

--- a/viz/narrations/review/src/renderers/index.js
+++ b/viz/narrations/review/src/renderers/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import { GridCollection } from "./GridCollection";
 import { JSONItem } from "./JSONItem";
 import { WordCloudItem } from "./WordCloudItem";

--- a/viz/narrations/review/src/utils.js
+++ b/viz/narrations/review/src/utils.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
 import config from "./config";
 
 function getHostname() {


### PR DESCRIPTION
Adds copyright headers to 29 files missing them. Generated build files were also tripping the copyright error; they've been exempted from the check instead.