### PR TITLE
Remove warning for .tar and .tgz downloads

### DIFF
--- a/ego4d/cli/config.py
+++ b/ego4d/cli/config.py
@@ -30,7 +30,17 @@ DATASETS_FILE = [
     "slowfast8x8_r101_k400",
 ]
 DATASETS_ALL = DATASETS_VIDEO + DATASETS_FILE
-DATASET_FILE_EXTENSIONS = [".mp4", ".json", ".jsonl", ".jpg", ".txt", ".csv", ".pt", ".tar", ".tgz"]
+DATASET_FILE_EXTENSIONS = [
+    ".mp4",
+    ".json",
+    ".jsonl",
+    ".jpg",
+    ".txt",
+    ".csv",
+    ".pt",
+    ".tar",
+    ".tgz"
+]
 
 
 class ValidatedConfig(NamedTuple):

--- a/ego4d/cli/config.py
+++ b/ego4d/cli/config.py
@@ -39,7 +39,10 @@ DATASET_FILE_EXTENSIONS = [
     ".csv",
     ".pt",
     ".tar",
-    ".tgz"
+    ".tgz",
+    ".ckpt",
+    ".pth",
+    ".zip",
 ]
 
 

--- a/ego4d/cli/config.py
+++ b/ego4d/cli/config.py
@@ -30,7 +30,7 @@ DATASETS_FILE = [
     "slowfast8x8_r101_k400",
 ]
 DATASETS_ALL = DATASETS_VIDEO + DATASETS_FILE
-DATASET_FILE_EXTENSIONS = [".mp4", ".json", ".jsonl", ".jpg", ".txt", ".csv", ".pt"]
+DATASET_FILE_EXTENSIONS = [".mp4", ".json", ".jsonl", ".jpg", ".txt", ".csv", ".pt", ".tar", ".tgz"]
 
 
 class ValidatedConfig(NamedTuple):


### PR DESCRIPTION
Our 3D scans are .tar files and our 3d scan keypoints are .tgz files. This adds them to the list of valid extensions so our cli doesn't throw warnings when you download them.