### PR TITLE
Omnivore feature extraction

### DIFF
--- a/ego4d/features/README.md
+++ b/ego4d/features/README.md
@@ -50,6 +50,17 @@ python3 ego4d/features/inference.py --config-name mvit_k400 schedule_config.run_
     +num_examples=4
 ```
 
+Omnivore on imagenet:
+```sh
+python3 ego4d/features/inference.py --config-name omnivore_image schedule_config.run_locally=1 \
+    +dataset_type="imagenet" \
+    +dataset_dir="/datasets01/imagenet_full_size/061417/" \
+    +set_to_use="train" \
+    +seed=1337 \
+    +top_k=2\
+    +num_examples=3
+```
+
 
 ### Schedule The Extraction
 

--- a/ego4d/features/configs/omnivore_image.yaml
+++ b/ego4d/features/configs/omnivore_image.yaml
@@ -1,0 +1,44 @@
+fps: 30
+force_yes: false
+io:
+  filter_completed: true
+  video_dir_path: /datasets01/ego4d_track2/v1/full_scale/
+  uid_list: null
+  video_limit: -1
+  out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/omnivore_video
+inference_config:
+  device: cuda
+  batch_size: 1
+  num_workers: 9
+  prefetch_factor: 2
+  fps: 30
+  frame_window: 1
+  stride: 5
+  include_audio: false
+  include_video: true
+schedule_config:
+  run_locally: false
+  log_folder: slurm_log/%j
+  timeout_min: 720
+  constraint: volta
+  slurm_partition: pixar
+  slurm_array_parallelism: 256
+  gpus_per_node: 1
+  cpus_per_task: 10
+  overhead: 2.0
+  time_per_forward_pass: 0.8
+  schedule_time_per_node: 10.0
+model_config:
+  model_name: "omnivore_swinB"
+  input_type: "image"
+  side_size: 256
+  crop_size: 224
+  mean:
+  - 0.485
+  - 0.456
+  - 0.406
+  std:
+  - 0.229
+  - 0.224
+  - 0.225
+model_module_str: ego4d.features.models.omnivore

--- a/ego4d/features/configs/omnivore_video.yaml
+++ b/ego4d/features/configs/omnivore_video.yaml
@@ -1,0 +1,44 @@
+fps: 30
+force_yes: false
+io:
+  filter_completed: true
+  video_dir_path: /datasets01/ego4d_track2/v1/full_scale/
+  uid_list: null
+  video_limit: -1
+  out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/omnivore_video
+inference_config:
+  device: cuda
+  batch_size: 1
+  num_workers: 9
+  prefetch_factor: 2
+  fps: 30
+  frame_window: 32
+  stride: 16
+  include_audio: false
+  include_video: true
+schedule_config:
+  run_locally: false
+  log_folder: slurm_log/%j
+  timeout_min: 720
+  constraint: volta
+  slurm_partition: pixar
+  slurm_array_parallelism: 256
+  gpus_per_node: 1
+  cpus_per_task: 10
+  overhead: 2.0
+  time_per_forward_pass: 0.8
+  schedule_time_per_node: 10.0
+model_config:
+  model_name: "omnivore_swinB"
+  input_type: "video"
+  side_size: 256
+  crop_size: 224
+  mean:
+  - 0.485
+  - 0.456
+  - 0.406
+  std:
+  - 0.229
+  - 0.224
+  - 0.225
+model_module_str: ego4d.features.models.omnivore

--- a/ego4d/features/dataset.py
+++ b/ego4d/features/dataset.py
@@ -59,7 +59,7 @@ class IndexableVideoDataset(torch.utils.data.Dataset):
 
 
 def get_all_clips(video, video_length, sampler):
-    last_clip_time = 0
+    last_clip_time = None
     annotation = {}
     n_clips = 0
     while True:

--- a/ego4d/features/inference.py
+++ b/ego4d/features/inference.py
@@ -13,6 +13,9 @@ from ego4d.features.config import Video, FeatureExtractConfig, load_model
 from ego4d.features.extract_features import (
     extract_features,
 )
+import torchvision.transforms as T
+import pandas as pd
+from PIL import Image
 
 
 @dataclass
@@ -48,8 +51,73 @@ def _load_kinetics_class_names():
     return kinetics_id_to_classname
 
 
+def _load_imagenet_label_dir_dict(dataset_dir: str):
+    path = os.path.join(dataset_dir, "labels.txt")
+    df = pd.read_csv(path, names=["dir_name", "class_name"], header=None)
+    return dict(zip(df.dir_name.tolist(), df.class_name.tolist()))
+
+
+def _load_imagenet_class_names():
+    # NOTE
+    # this class mapping is for omnivore
+    # this may or may not be applicable to you
+    # wget https://s3.amazonaws.com/deep-learning-models/image-models/imagenet_class_index.json
+    with open("/private/home/miguelmartin/ego4d/ego4d_public/imagenet_class_index.json", "r") as f:
+        imagenet_classnames = json.load(f)
+
+    # Create an id to label name mapping
+    imagenet_id_to_classname = {}
+    for k, v in imagenet_classnames.items():
+        imagenet_id_to_classname[k] = v[1]
+    return imagenet_id_to_classname
+
+
 def inference_imagenet(config: RunInferenceConfig):
-    raise AssertionError("not implemented")
+    # taken from https://github.com/facebookresearch/omnivore/blob/main/inference_tutorial.ipynb
+    label_mapping = _load_imagenet_class_names()
+    label_dir_dict = _load_imagenet_label_dir_dict(config.dataset_dir)
+
+    image_set_dir = os.path.join(config.dataset_dir, config.set_to_use)
+    labels = os.listdir(image_set_dir)
+
+    for i in range(config.num_examples):
+        expected_label = random.sample(labels, 1)[0]
+        expected_label_value = label_dir_dict[expected_label]
+
+        images_dir = os.path.join(image_set_dir, expected_label)
+        images_in_dir = os.listdir(images_dir)
+
+        image_path = random.sample(images_in_dir, 1)[0]
+        image_path = f"{images_dir}/{image_path}"
+
+        image = Image.open(image_path).convert("RGB")
+        image_transform = T.Compose(
+            [
+                T.Resize(224),
+                T.CenterCrop(224),
+                T.ToTensor(),
+                T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            ]
+        )
+        image = image_transform(image)
+        image = image[None, :, None, ...].to(config.inference_config.device)
+        model = load_model(config, patch_final_layer=False)
+        predictions = model(image)
+
+        pred_classes = torch.nn.Softmax(dim=1)(predictions).squeeze()
+        top_k = pred_classes.topk(k=config.top_k)
+        predictions_strs = [
+            f"- {label_mapping[str(idx.item())]}: {prob.item():.2%}"
+            for prob, idx in zip(top_k.values, top_k.indices)
+        ]
+        predictions_summary = '\n'.join(predictions_strs)
+        print(f"""Example: {image_path}
+
+Expected label: {expected_label_value}
+Predicted labels:
+{predictions_summary}
+    """)
+
 
 
 def inference_k400(config: RunInferenceConfig):
@@ -61,9 +129,6 @@ def inference_k400(config: RunInferenceConfig):
     - <basedir>/val
     - <basedir>/test
     """
-    if config.seed is not None:
-        random.seed(config.seed)
-
     video_set_dir = os.path.join(config.dataset_dir, config.set_to_use)
 
     model = load_model(config, patch_final_layer=False)
@@ -111,6 +176,9 @@ Predicted labels:
 
 @hydra.main(config_path="configs", config_name=None)
 def main(config: RunInferenceConfig):
+    if config.seed is not None:
+        random.seed(config.seed)
+
     assert config.dataset_type in ("k400", "imagenet")
     if config.dataset_type == "k400":
         inference_k400(config)

--- a/ego4d/features/models/omnivore.py
+++ b/ego4d/features/models/omnivore.py
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from pytorchvideo.transforms import (
+    ApplyTransformToKey,
+    ShortSideScale,
+    UniformTemporalSubsample,
+)
+from torch.nn import Module, Identity
+from torchvision.transforms import Compose, Lambda
+from ego4d.features.config import InferenceConfig, BaseModelConfig
+
+from torchvision.transforms._transforms_video import (
+    CenterCropVideo,
+    NormalizeVideo,
+)
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    model_name: str = "omnivore_swinB"
+    input_type: str = "video"
+    side_size: int = 256
+    crop_size: int = 224
+    mean: Tuple[float] = (0.485, 0.456, 0.406)
+    std: Tuple[float] = (0.229, 0.224, 0.225)
+
+
+class WrapModel(Module):
+    def __init__(self, model: Module, input_type: str):
+        super().__init__()
+        self.model = model
+        self.input_type = input_type
+
+    def forward(self, x) -> torch.Tensor:
+        return self.model(x, input_type=self.input_type)
+
+
+def load_model(inference_config: InferenceConfig, config: ModelConfig, patch_final_layer: bool = True) -> Module:
+    model = torch.hub.load("facebookresearch/omnivore", model=config.model_name)
+
+    if patch_final_layer:
+        model.heads.image = Identity()
+        model.heads.video = Identity()
+        model.heads.rgbd = Identity()
+
+    # Set to GPU or CPU
+    model = WrapModel(model, config.input_type)
+    model = model.eval()
+    model = model.to(inference_config.device)
+    return model
+
+
+def get_transform(inference_config: InferenceConfig, config: ModelConfig):
+    if config.input_type == "video":
+        transforms = [
+            UniformTemporalSubsample(inference_config.frame_window),
+            Lambda(lambda x: x / 255.0),
+            NormalizeVideo(config.mean, config.std),
+            ShortSideScale(size=config.side_size),
+            CenterCropVideo(config.crop_size),
+        ]
+    else:
+        assert inference_config.frame_window == 1
+        transforms = [
+            UniformTemporalSubsample(inference_config.frame_window),
+            NormalizeVideo(config.mean, config.std),
+            ShortSideScale(size=config.side_size),
+            CenterCropVideo(config.crop_size),
+        ]
+
+    return ApplyTransformToKey(
+        key="video",
+        transform=Compose(transforms),
+    )


### PR DESCRIPTION
Similar to #74 

Depends on D34811417

Adds [Omnivore]()

- 32 frame window & 1 frame window for omnivore_video.yaml and omnivore_image.yaml respectively
- Stride to 5 frames for both

# Testing

K400 inference:

```
python3 ego4d/features/inference.py --config-name omnivore_video schedule_config.run_locally=1 \
    +dataset_type="k400" \
    +dataset_dir="/datasets01/Kinetics400_Frames/videos/" \
    +set_to_use="val" \
    +seed=1337 \
    +top_k=2\
    +num_examples=4
```

```
Example 1: /datasets01/Kinetics400_Frames/videos/val/smoking/_bMKjdjZO8Y_000021_000031.mp4

Expected label: smoking
Predicted labels:
- smoking: 76.26%
- smoking hookah: 3.57%

Example 2: /datasets01/Kinetics400_Frames/videos/val/training_dog/QqEUyMzRR7s_000125_000135.mp4

Expected label: training_dog
Predicted labels:
- training dog: 95.54%
- walking the dog: 0.57%

Example 3: /datasets01/Kinetics400_Frames/videos/val/shaving_head/pI8CK8323s4_000083_000093.mp4

Expected label: shaving_head
Predicted labels:
- shaving head: 91.54%
- getting a haircut: 1.38%

Example 4: /datasets01/Kinetics400_Frames/videos/val/using_remote_controller_(not_gaming)/C0iEsvqb8J4_000000_000010.mp4

Expected label: using_remote_controller_(not_gaming)
Predicted labels:
- driving tractor: 55.09%
- unloading truck: 4.64%
```