### PR TITLE
Crop by half for stereoscopic videos

### DIFF
--- a/ego4d/features/configs/mvit_k400.yaml
+++ b/ego4d/features/configs/mvit_k400.yaml
@@ -3,6 +3,7 @@ force_yes: false
 io:
   filter_completed: true
   video_dir_path: /datasets01/ego4d_track2/v1/full_scale/
+  ego4d_download_dir: /checkpoint/miguelmartin/ego4d/
   uid_list: null
   video_limit: -1
   out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/mvit_k400/

--- a/ego4d/features/configs/omnivore_video.yaml
+++ b/ego4d/features/configs/omnivore_video.yaml
@@ -3,6 +3,7 @@ force_yes: false
 io:
   filter_completed: true
   video_dir_path: /datasets01/ego4d_track2/v1/full_scale/
+  ego4d_download_dir: /checkpoint/miguelmartin/ego4d/
   uid_list: null
   video_limit: -1
   out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/omnivore_video

--- a/ego4d/features/configs/slowfast_r101_8x8.yaml
+++ b/ego4d/features/configs/slowfast_r101_8x8.yaml
@@ -3,6 +3,7 @@ force_yes: false
 io:
   filter_completed: true
   video_dir_path: /datasets01/ego4d_track2/v1/full_scale/
+  ego4d_download_dir: /checkpoint/miguelmartin/ego4d/
   uid_list: null
   video_limit: -1
   out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/test/action_features

--- a/ego4d/features/dataset.py
+++ b/ego4d/features/dataset.py
@@ -8,6 +8,7 @@ from ego4d.features.config import FeatureExtractConfig, get_transform, Video
 from pytorchvideo.data import UniformClipSampler
 from pytorchvideo.data.encoded_video import EncodedVideo
 from torch.utils.data import DataLoader
+from torchvision.transforms import Compose
 
 
 class IndexableVideoDataset(torch.utils.data.Dataset):
@@ -50,12 +51,36 @@ class IndexableVideoDataset(torch.utils.data.Dataset):
             "video_index": idx,
             "clip_index": clip_index,
             "aug_index": aug_index,
+            "is_stereo": video.is_stereo,
             # TODO
             # **info_dict,
             # **({"audio": audio_samples} if audio_samples is not None else {})
         }
         sample_dict = self.transform(sample_dict)
         return sample_dict
+
+
+class CropIfStereo:
+    def __init__(self):
+        pass
+
+    def __call__(self, x):
+        if x["is_stereo"]:
+            v = x["video"]
+            assert len(v.shape) == 4
+            x["video"] = v[:, :, :, 0 : v.shape[-1] // 2]
+
+            # edge case where some videos are incorrectly
+            # encoded from source and weren't corrected
+            if v.shape[-1] < v.shape[-2]:
+                x["video"] = torch.nn.functional.interpolate(
+                    x["video"],
+                    size=(x["video"].shape[-1], x["video"].shape[-2] // 2),
+                    mode="bilinear",
+                )
+            # for debugging
+            # torchvision.utils.save_image(x["video"].permute(1, 0, 2, 3)[0] / 255.0, fp="/tmp/test.jpg")  # noqa
+        return x
 
 
 def get_all_clips(video, video_length, sampler):
@@ -90,7 +115,12 @@ def create_dset(
         backpad_last=True,
     )
 
-    transform = get_transform(config)
+    transform = Compose(
+        [
+            CropIfStereo(),
+            get_transform(config),
+        ]
+    )
     return IndexableVideoDataset(videos, clip_sampler, transform)
 
 

--- a/ego4d/features/models/mvit.py
+++ b/ego4d/features/models/mvit.py
@@ -62,7 +62,11 @@ def get_transform(inference_config: InferenceConfig, config: ModelConfig):
     if config.pretrained_dataset == "imagenet":
         # NOTE untested due to MViT imagenet not not available on torch hub
         transforms += [Lambda(lambda x: x.squeeze_(2))]
-    return ApplyTransformToKey(
-        key="video",
-        transform=Compose(transforms),
+    return Compose(
+        [
+            ApplyTransformToKey(
+                key="video",
+                transform=Compose(transforms),
+            )
+        ]
     )

--- a/ego4d/features/profile.py
+++ b/ego4d/features/profile.py
@@ -12,8 +12,16 @@ from ego4d.features.slurm import create_executor
 
 
 def profile_extraction(config: FeatureExtractConfig):
-    videos, _ = get_videos(config)
-    videos = [v for v in videos if v.frame_count > 1000 and v.frame_count <= 2000]
+    _, videos = get_videos(config)
+    # videos = [v for v in videos if v.frame_count > 1000 and v.frame_count <= 2000]
+    # videos = [v for v in videos if v.is_stereo]
+    videos = [
+        v
+        for v in videos
+        # width > height
+        if v.uid == "999755f8-ae42-4030-9e0d-ad2c5c470cb1"
+        # if v.uid == "10a4f3e3-0f2d-4481-89da-58a8bb983341"
+    ]
     videos = videos[0:1]
 
     print("Frame count=", videos[0].frame_count)
@@ -21,7 +29,7 @@ def profile_extraction(config: FeatureExtractConfig):
     print(f"Got {len(videos)} videos")
 
     batch_sizes = [1]
-    num_workers = [15]
+    num_workers = [0]
     model = load_model(config)
 
     num_examples = -1


### PR DESCRIPTION
Title. This also handles a subtle edge-case for some stereoscopic videos which have the wrong dimensions.

Tested with the profile.py script on stereoscopic videos via outputting an image file and inspecting the result.