### PR TITLE
Features data load fix

### DIFF
--- a/ego4d/features/config.py
+++ b/ego4d/features/config.py
@@ -44,6 +44,8 @@ class InputOutputConfig:
     ego4d_download_dir: str = "/checkpoint/miguelmartin/ego4d/"
     uid_list: Optional[List[str]] = None
     video_limit: int = -1
+    debug_mode: bool = False
+    debug_path: str = "/checkpoint/miguelmartin/ego4d_track2/v1/debug_frames"
 
     # output
     out_path: str = (

--- a/ego4d/features/configs/mvit_k400.yaml
+++ b/ego4d/features/configs/mvit_k400.yaml
@@ -7,6 +7,8 @@ io:
   uid_list: null
   video_limit: -1
   out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/mvit_k400/
+  debug_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/mvit_k400_debug
+  debug_mode: false
 inference_config:
   device: cuda
   batch_size: 1

--- a/ego4d/features/configs/omnivore_video.yaml
+++ b/ego4d/features/configs/omnivore_video.yaml
@@ -7,30 +7,32 @@ io:
   uid_list: null
   video_limit: -1
   out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/omnivore_video
+  debug_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/omnivore_video_debug
+  debug_mode: false
 inference_config:
   device: cuda
   batch_size: 1
-  num_workers: 9
-  prefetch_factor: 2
+  num_workers: 10
+  prefetch_factor: 3
   fps: 30
   frame_window: 32
-  stride: 6
+  stride: 16
   include_audio: false
   include_video: true
 schedule_config:
   run_locally: false
   log_folder: slurm_log/%j
-  timeout_min: 2400
+  timeout_min: 3750
   constraint: volta
   slurm_partition: pixar
   slurm_array_parallelism: 256
   gpus_per_node: 1
   cpus_per_task: 10
-  overhead: 1.3
-  time_per_forward_pass: 0.8
+  overhead: 1.1
+  time_per_forward_pass: 2.5
   schedule_time_per_node: 10.0
 model_config:
-  model_name: "omnivore_swinB"
+  model_name: "omnivore_swinB_imagenet21k"
   input_type: "video"
   side_size: 256
   crop_size: 224

--- a/ego4d/features/configs/slowfast_r101_8x8.yaml
+++ b/ego4d/features/configs/slowfast_r101_8x8.yaml
@@ -6,11 +6,13 @@ io:
   ego4d_download_dir: /checkpoint/miguelmartin/ego4d/
   uid_list: null
   video_limit: -1
-  out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/test/action_features
+  out_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/slowfast
+  debug_path: /checkpoint/miguelmartin/ego4d_track2_features/full_scale/action_features_debug
+  debug_mode: false
 inference_config:
   device: cuda
   batch_size: 1
-  num_workers: 9
+  num_workers: 10
   prefetch_factor: 2
   fps: 30
   frame_window: 32
@@ -20,14 +22,14 @@ inference_config:
 schedule_config:
   run_locally: false
   log_folder: slurm_log/%j
-  timeout_min: 720
+  timeout_min: 3200
   constraint: volta
   slurm_partition: pixar
-  slurm_array_parallelism: 256
+  slurm_array_parallelism: 128
   gpus_per_node: 1
   cpus_per_task: 10
-  overhead: 2.0
-  time_per_forward_pass: 0.8
+  overhead: 1.1
+  time_per_forward_pass: 2.4
   schedule_time_per_node: 10.0
 model_config:
   model_path: null

--- a/ego4d/features/models/mvit.py
+++ b/ego4d/features/models/mvit.py
@@ -5,11 +5,7 @@ from typing import Tuple
 
 from ego4d.features.config import BaseModelConfig, InferenceConfig
 from pytorchvideo.models.hub.vision_transformers import mvit_base_16, mvit_base_32x3
-from pytorchvideo.transforms import (
-    ApplyTransformToKey,
-    ShortSideScale,
-    UniformTemporalSubsample,
-)
+from pytorchvideo.transforms import ApplyTransformToKey, ShortSideScale
 from torch.nn import Identity, Module
 from torchvision.transforms import Compose, Lambda
 from torchvision.transforms._transforms_video import CenterCropVideo, NormalizeVideo
@@ -52,7 +48,6 @@ def load_model(
 
 def get_transform(inference_config: InferenceConfig, config: ModelConfig):
     transforms = [
-        UniformTemporalSubsample(inference_config.frame_window),
         Lambda(lambda x: x / 255.0),
         NormalizeVideo(config.mean, config.std),
         ShortSideScale(size=config.side_size),

--- a/ego4d/features/models/omnivore.py
+++ b/ego4d/features/models/omnivore.py
@@ -5,11 +5,7 @@ from typing import Tuple
 
 import torch
 from ego4d.features.config import BaseModelConfig, InferenceConfig
-from pytorchvideo.transforms import (
-    ApplyTransformToKey,
-    ShortSideScale,
-    UniformTemporalSubsample,
-)
+from pytorchvideo.transforms import ApplyTransformToKey, ShortSideScale
 from torch.nn import Identity, Module
 from torchvision.transforms import Compose, Lambda
 from torchvision.transforms._transforms_video import CenterCropVideo, NormalizeVideo
@@ -57,7 +53,6 @@ def load_model(
 def get_transform(inference_config: InferenceConfig, config: ModelConfig):
     if config.input_type == "video":
         transforms = [
-            UniformTemporalSubsample(inference_config.frame_window),
             Lambda(lambda x: x / 255.0),
             NormalizeVideo(config.mean, config.std),
             ShortSideScale(size=config.side_size),
@@ -66,7 +61,6 @@ def get_transform(inference_config: InferenceConfig, config: ModelConfig):
     else:
         assert inference_config.frame_window == 1
         transforms = [
-            UniformTemporalSubsample(inference_config.frame_window),
             NormalizeVideo(config.mean, config.std),
             ShortSideScale(size=config.side_size),
             CenterCropVideo(config.crop_size),

--- a/ego4d/features/models/slowfast.py
+++ b/ego4d/features/models/slowfast.py
@@ -5,11 +5,7 @@ from typing import Optional, Tuple
 
 import torch
 from ego4d.features.config import BaseModelConfig, InferenceConfig
-from pytorchvideo.transforms import (
-    ApplyTransformToKey,
-    ShortSideScale,
-    UniformTemporalSubsample,
-)
+from pytorchvideo.transforms import ApplyTransformToKey, ShortSideScale
 from torch.nn import Identity, Module
 from torchvision.transforms import Compose, Lambda
 
@@ -93,7 +89,6 @@ def get_transform(inference_config: InferenceConfig, config: ModelConfig):
         key="video",
         transform=Compose(
             [
-                UniformTemporalSubsample(inference_config.frame_window),
                 Lambda(lambda x: x / 255.0),
                 NormalizeVideo(config.mean, config.std),
                 ShortSideScale(size=config.side_size),

--- a/ego4d/features/profile.py
+++ b/ego4d/features/profile.py
@@ -18,8 +18,11 @@ def profile_extraction(config: FeatureExtractConfig):
     videos = [
         v
         for v in videos
+        if v.frame_count > 1000 and v.frame_count <= 2000
         # width > height
-        if v.uid == "999755f8-ae42-4030-9e0d-ad2c5c470cb1"
+        # if v.uid == "ff90b2a6-48ec-4116-b171-96ba8d61caf8"
+        # if v.uid == "d7f51e37-9858-489b-a57e-397fce7f6895"
+        # if v.uid == "999755f8-ae42-4030-9e0d-ad2c5c470cb1"
         # if v.uid == "10a4f3e3-0f2d-4481-89da-58a8bb983341"
     ]
     videos = videos[0:1]
@@ -28,20 +31,20 @@ def profile_extraction(config: FeatureExtractConfig):
 
     print(f"Got {len(videos)} videos")
 
-    batch_sizes = [1]
-    num_workers = [0]
+    batch_sizes = [1, 1, 1, 1, 1]
+    num_workers = [9, 10, 10, 10, 10]
+    prefetch_factor = [2, 3, 4, 5]
     model = load_model(config)
 
     num_examples = -1
 
     print(
-        "num_examples,batch_size,num_workers,total,mean,forward_pass,to_load,transfer_to_device"
+        "prefetch_factor,batch_size,num_workers,total,mean,forward_pass,to_load,transfer_to_device"  # noqa
     )
-    for batch_size, num_workers in zip(batch_sizes, num_workers):
+    for batch_size, nm, pf in zip(batch_sizes, num_workers, prefetch_factor):
         config.inference_config.batch_size = batch_size
-        config.inference_config.num_workers = num_workers
-
-        print(batch_size, num_workers)
+        config.inference_config.num_workers = nm
+        config.inference_config.prefetch_factor = pf
 
         t1 = time.time()
         time_stats = extract_features(
@@ -50,6 +53,7 @@ def profile_extraction(config: FeatureExtractConfig):
             model=model,
             log_info=False,
             max_examples=num_examples,
+            silent=True,
         ).time_stats
         t2 = time.time()
 
@@ -71,11 +75,11 @@ def profile_extraction(config: FeatureExtractConfig):
 
         if batch_size == 0:
             print(
-                f"{num_examples},{batch_size},{num_workers},{total_time},{mean_sum},{forward_pass.mean()},{to_load.mean()},{transfer_time.mean()}"
+                f"{prefetch_factor},{batch_size},{num_workers},{total_time},{mean_sum},{forward_pass.mean()},{to_load.mean()},{transfer_time.mean()}"  # noqa
             )
         else:
             print(
-                f"{num_examples},{batch_size},{num_workers},{total_time},{mean_sum},{forward_pass.mean()/batch_size},{to_load.mean()/batch_size},{transfer_time.mean()/batch_size}"
+                f"{prefetch_factor},{batch_size},{num_workers},{total_time},{mean_sum},{forward_pass.mean()/batch_size},{to_load.mean()/batch_size},{transfer_time.mean()/batch_size}"  # noqa
             )
 
 

--- a/ego4d/features/slurm.py
+++ b/ego4d/features/slurm.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 import hydra
+
+import numpy as np
 import submitit
 import torch
 from ego4d.features.config import (
@@ -62,20 +64,20 @@ def greedy_create_batches(
     while i <= j:
         old_i, old_j = i, j
 
-        while j >= i and curr_time + times[j] <= max_time_per_batch:
-            curr.append((videos[j], times[j]))
-            curr_time += times[j]
-            j -= 1
-
         while i <= j and curr_time + times[i] <= max_time_per_batch:
             curr.append((videos[i], times[i]))
             curr_time += times[i]
             i += 1
 
+        while j >= i and curr_time + times[j] <= max_time_per_batch:
+            curr.append((videos[j], times[j]))
+            curr_time += times[j]
+            j -= 1
+
         assert (
             i != old_i or j != old_j
         ), f"""
-        Could not batch it up - 
+        Could not batch it up -
             i = {i}, j = {j}
             old_i = {old_i}, old_j = {old_j}
             time_i = {times[i]}, time_j = {times[j]}
@@ -110,7 +112,12 @@ def batch_videos(
     videos: List[Video], config: FeatureExtractConfig
 ) -> List[List[Video]]:
     # estimate each time to extract per sub-clip
-    num_forward_passes = [num_fvs(v, config.inference_config) for v in videos]
+    num_forward_passes = [
+        np.ceil(
+            num_fvs(v, config.inference_config) / config.inference_config.batch_size
+        )
+        for v in videos
+    ]
     times = [
         config.schedule_config.overhead
         * n

--- a/ego4d/features/visualize_dataloader.py
+++ b/ego4d/features/visualize_dataloader.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
+import functools
+
+import random
+
+import hydra
+from ego4d.features.config import FeatureExtractConfig, get_videos, load_model
+from ego4d.features.extract_features import extract_features
+from ego4d.features.slurm import create_executor
+
+
+def visualize_extraction(config: FeatureExtractConfig):
+    _, videos = get_videos(config)
+    videos = [v for v in videos if v.frame_count > 1000 and v.frame_count <= 2000]
+    random.shuffle(videos)
+    videos = videos[0:5]
+
+    print("Frame count=", videos[0].frame_count)
+    print(f"Got {len(videos)} videos")
+
+    config.io.debug_mode = True
+    model = load_model(config)
+
+    extract_features(
+        videos=videos,
+        config=config,
+        model=model,
+        log_info=False,
+        max_examples=-1,
+        silent=True,
+    )
+
+
+@hydra.main(config_path="configs", config_name=None)
+def schedule_profile_extraction(config: FeatureExtractConfig):
+    if config.schedule_config.run_locally:
+        visualize_extraction(config)
+    else:
+        executor = create_executor(config.schedule_config)
+        job = executor.submit(functools.partial(visualize_extraction, config=config))
+        print(f"{job}")
+
+        # wait for the job
+        job.result()
+
+
+if __name__ == "__main__":
+    schedule_profile_extraction()  # pyre-ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,10 @@
-boto3
-tqdm
+pytorchvideo
+einops==0.4.1
+numpy==1.22.3
+pandas==1.4.1
+speechbrain==0.5.11
+submitit==1.4.1
+timm==0.5.4
+torch==1.11.0
+torchaudio==0.11.0
+torchvision==0.12.0


### PR DESCRIPTION
Depends on #92 

With no seek (as in the code), the number of requested frames retrieved will be less than expected. Specifically the first stride frames will be not included in every window fed into the model. This is some serious negligence on my part (I really don't know what I was thinking at the time...). SlowFast features should be unaffected. This went un-noticed due to the transform: `UniformTemporalSubsample` which padded the frames to the window size - which was previously there due to EncodedVideo being imprecise previously.

This solution is a bit hacky, and does not perform a seek. Seeking simply doesn't work on the FAIR cluster with PyAV (have yet to try locally).

Instead I:
1. Iterate over each frame on each worker, caching them into a fixed window buffer
2. On the next iteration: iterate over the cache window, checking if there's any frames overlapping with the current window to retrieve
3. Iterate over the container for more possible frames

Note this does depend on the fact that the dataloader will request examples in order (which it does).

Alternative options are not feasible at this point.. I did also try decord (via compilation) and I cannot get it to work with the FAIR cluster on our set of videos.

This doesn't support audio, so I'll need to fix my other PRs.