### PR TITLE
Add Annotation Transform Notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ notebooks/moments_cvpr/mobilenet_v3_small-047dcff4.pth
 notebooks/moments_cvpr/moments.ckpt
 notebooks/moments_cvpr/r2plus1d_18-91a641e6.pth
 notebooks/moments_cvpr/resnet18-f37072fd.pth
+.DS_Store

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -10,3 +10,4 @@ numpy==1.22.0
 opencv_python==4.5.5.62
 pandas==1.3.5
 progressbar33==2.4
+deepdiff==5.8.1

--- a/notebooks/transform_annotations.ipynb
+++ b/notebooks/transform_annotations.ipynb
@@ -1,0 +1,379 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c17d5c90-a79c-452b-ac00-546b87a92dea",
+   "metadata": {},
+   "source": [
+    "# Ego4D Annotation Transformation\n",
+    "This notebook helps you transform Ego4D annotations into different variants, e.g. with scaled down bboxes.\n",
+    "\n",
+    "## Prerequisites\n",
+    "1. Use the [Ego4D CLI](https://ego4d-data.org/docs/start-here/) to download the annotations dataset.\n",
+    "2. Install all the packages in this notebook using `requirements.txt`.\n",
+    "\n",
+    "## **Useful Links:**\n",
+    "\n",
+    "[Ego4D Docs - Start Here!](https://ego4d-data.org/docs/start-here/#Download-The-CLI)\n",
+    "\n",
+    "[Data Overview](https://ego4d-data.org/docs/data-overview/)\n",
+    "\n",
+    "[Official Ego4D Site](https://ego4d-data.org/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8886a132-5242-43e1-a117-67cc1afc89ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set your options here\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "CLI_OUTPUT_DIR = \"/Users/<userid>/ego4d\" # Replace with the full path to the --output_directory you pass to the cli\n",
+    "VERSION = \"v1\"\n",
+    "\n",
+    "METADATA_PATH = os.path.join(CLI_OUTPUT_DIR, \"ego4d.json\")\n",
+    "ANNOTATIONS_PATH = os.path.join(CLI_OUTPUT_DIR, VERSION, \"annotations\")\n",
+    "\n",
+    "assert os.path.exists(METADATA_PATH), f\"Metadata doesn't exist at {METADATA_PATH}. Is the CLI_OUTPUT_DIR right? Do you satisfy the pre-requisites?\"\n",
+    "assert os.path.exists(os.path.join(ANNOTATIONS_PATH, \"manifest.csv\")), \"Annotation metadata doesn't exist. Did you download it with the CLI?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "734f3d6f-6a80-4051-87fc-94a875fa03e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports and consts\n",
+    "import random\n",
+    "import simplejson as json\n",
+    "\n",
+    "from collections import namedtuple\n",
+    "from typing import List\n",
+    "\n",
+    "annotation_files = [\n",
+    "    \"av_train.json\",\n",
+    "    \"av_val.json\",\n",
+    "    \n",
+    "    \"fho_hands_train.json\",\n",
+    "    \"fho_hands_val.json\",\n",
+    "    # \"fho_lta_taxonomy.json\",\n",
+    "    \"fho_lta_train.json\",\n",
+    "    \"fho_lta_val.json\",\n",
+    "    \"fho_scod_train.json\",\n",
+    "    \"fho_scod_val.json\",\n",
+    "    \"fho_sta_train.json\",\n",
+    "    \"fho_sta_val.json\",\n",
+    "    \n",
+    "    # \"manifest.csv\",\n",
+    "    # \"manifest.ver\",\n",
+    "    \n",
+    "    \"moments_train.json\",\n",
+    "    \"moments_val.json\",\n",
+    "    \n",
+    "    \"narration.json\",\n",
+    "    # \"narration_noun_taxonomy.csv\",\n",
+    "    # \"narration_verb_taxonomy.csv\",\n",
+    "    \n",
+    "    \"nlq_train.json\",\n",
+    "    \"nlq_val.json\",\n",
+    "    \"vq_train.json\",\n",
+    "    \"vq_val.json\"\n",
+    "]\n",
+    "\n",
+    "def load_json_from_path(path):\n",
+    "    with open(path) as json_file:\n",
+    "        return json.load(json_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4328448c-fd41-41d6-9bd6-ec7ec5ad8da4",
+   "metadata": {},
+   "source": [
+    "# Load Metadata Into Memory\n",
+    "First load video metadata into a dict. This is useful for mappers/selectors that need video resolution or other info."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "675e1859-40c2-43a1-ac7b-1730e91d81a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load ego4D video metadata into a dictionary for easy indexing\n",
+    "meta = load_json_from_path(METADATA_PATH)\n",
+    "\n",
+    "metadata = {\n",
+    "    video['video_uid']: {\n",
+    "        **{\n",
+    "            k: v\n",
+    "            for k, v in video.items()\n",
+    "                if k != 'video_metadata'\n",
+    "        },\n",
+    "        **video['video_metadata']\n",
+    "    }\n",
+    "    for video in meta['videos']\n",
+    "}\n",
+    "\n",
+    "print(len(metadata))\n",
+    "print(f\"Keys Accessible in Metadata: {list(metadata[list(metadata.keys())[0]].keys())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b631b8cb-6896-4e4f-89c1-9343c394864f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Define JSON Transformation Utils\n",
+    "We transform the annotation jsons with a selector/mapper architecture. The selector gets a json object and decides whether it needs to be changed. If it does, then the mapper takes in that object and returns a transformed one to take its place.\n",
+    "\n",
+    "We call each selector/mapper pair a 'Transform'.\n",
+    "\n",
+    "We input an ordered list of Transforms to be applied; only the first matching Transform for each object is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95e4ceef-a6fe-4a42-ab04-c6333bc8253d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Applies a list of Transforms to the given json object\n",
+    "# using a recursive DFS\n",
+    "# \n",
+    "# Each Transform is a selector and a mapper. The selector\n",
+    "# identifies json objects that should be transformed, and\n",
+    "# the mapper transforms them.\n",
+    "# \n",
+    "# Selectors have type: (obj: any, context: dict) -> bool\n",
+    "# Mappers have type: (obj: any, context: dict) -> any\n",
+    "# \n",
+    "# Context fields are passed into the selector/mapper for\n",
+    "# all children once they're seen. See wiki for schema\n",
+    "# structure and add any context fields you need to use\n",
+    "# below.\n",
+    "\n",
+    "Transform = namedtuple('Transformation', 'selector mapper')\n",
+    "context_fields = ['video_uid', 'video_id', 'clip_uid']\n",
+    "\n",
+    "def _apply_transforms(obj, transforms, context=None):\n",
+    "    context = context or {}\n",
+    "    \n",
+    "    for transform in transforms:\n",
+    "        selector, mapper = transform\n",
+    "        if selector(obj, context):\n",
+    "            return mapper(obj, context)\n",
+    "        \n",
+    "    if type(obj) is dict:\n",
+    "#       Context fields are propagated down to their children in\n",
+    "#       the context object, so mappers/selectors can use them\n",
+    "        context = {\n",
+    "            **context,\n",
+    "            **{\n",
+    "                k: obj[k]\n",
+    "                for k in context_fields\n",
+    "                    if k in obj\n",
+    "            }\n",
+    "        }\n",
+    "        \n",
+    "        return {\n",
+    "            k: _apply_transforms(v, transforms, {**context, 'key': k})\n",
+    "            for k, v in obj.items()\n",
+    "        }\n",
+    "    elif type(obj) is list:\n",
+    "        return [\n",
+    "            _apply_transforms(v, transforms, context)\n",
+    "            for v in obj\n",
+    "        ]\n",
+    "    return obj\n",
+    "\n",
+    "def transform_annotations(input_path: str, output_path: str, transforms: List[Transform]):\n",
+    "    print(f\"\\nloading {input_path}...\")\n",
+    "    original_obj = load_json_from_path(input_path)\n",
+    "    print(\"transforming...\")\n",
+    "    transformed_obj = _apply_transforms(original_obj, transforms)\n",
+    "    print(f\"writing {output_path}...\")\n",
+    "    with open(output_path, 'w') as f:\n",
+    "        json.dump(transformed_obj, f)\n",
+    "    print(\"done.\")\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a76aea2f-ceb9-4883-927c-ec7c9254d648",
+   "metadata": {},
+   "source": [
+    "# Define Transforms\n",
+    "Here are a few sample Transforms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4f6a96e-2e12-4886-a8a3-be61c4494358",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scale_ratio(video_uid, new_height):\n",
+    "    return float(new_height) / metadata[video_uid]['display_resolution_height']\n",
+    "\n",
+    "# dummy example, increments all floats/ints by 1\n",
+    "increment_nums = Transform(\n",
+    "    lambda obj, ctx: isinstance(obj, int) or isinstance(obj, float), # Selector\n",
+    "    lambda obj, ctx: obj + 1 # Mapper\n",
+    ")\n",
+    "\n",
+    "# scale bboxes - works for the schemas of av, fho_scod, and vq\n",
+    "def scale_bboxes(new_height): return Transform(\n",
+    "    lambda obj, ctx: type(obj) is dict and 'x' in obj and 'y' in obj and 'width' in obj and 'height' in obj, # Selector\n",
+    "    lambda obj, ctx: { # Mapper\n",
+    "        **obj, # av has extra properties to retain, e.g. person id\n",
+    "        'x': obj['x'] * scale_ratio(ctx['video_uid'], new_height),\n",
+    "        'y': obj['y'] * scale_ratio(ctx['video_uid'], new_height),\n",
+    "        'width': obj['width'] * scale_ratio(ctx['video_uid'], new_height),\n",
+    "        'height': obj['height'] * scale_ratio(ctx['video_uid'], new_height),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# scale bboxes - works for the schema of fho_sta\n",
+    "def fho_sta_scale_boxes(new_height): return Transform(\n",
+    "    lambda obj, ctx: type(obj) is list and ctx.get('key') == 'box', # Selector\n",
+    "    lambda obj, ctx: [ # Mapper\n",
+    "        point * scale_ratio(ctx['video_id'], new_height)\n",
+    "        for point in obj\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd9e8f23-e9af-43bc-9fcf-d7df1fc70761",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Execute transformations and output new annotation files\n",
+    "Now we apply these Transforms to the original annotation files and create new ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3818b340-843c-4e72-ac2d-05377b61215f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# transform_jobs has format: [\n",
+    "#    ( input file (in annotations directory), output path, list of Transforms to apply ), ...\n",
+    "# ]\n",
+    "transform_jobs = [\n",
+    "    ('av_train.json', 'av_train_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('av_val.json', 'av_val_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('fho_hands_train.json', 'fho_hands_train_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('fho_hands_val.json', 'fho_hands_val_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('fho_scod_train.json', 'fho_scod_train_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('fho_scod_val.json', 'fho_scod_val_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('vq_train.json', 'vq_train_height-540.json', [scale_bboxes(540)]),\n",
+    "    ('vq_val.json', 'vq_val_height-540.json', [scale_bboxes(540)]),\n",
+    "    \n",
+    "    ('fho_sta_train.json', 'fho_sta_train_height-540.json', [fho_sta_scale_boxes(540)]),\n",
+    "    ('fho_sta_val.json', 'fho_sta_val_height-540.json', [fho_sta_scale_boxes(540)]),\n",
+    "]\n",
+    "\n",
+    "for j in transform_jobs:\n",
+    "    transform_annotations(os.path.join(ANNOTATIONS_PATH, j[0]), j[1], j[2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe94aeb9-c891-485a-a4d2-edb14783f7d0",
+   "metadata": {},
+   "source": [
+    "# Test Outputs\n",
+    "\n",
+    "Always validate the annotation output before using it. We look at a specific json path to verify that the bboxes have been scaled appropriately, then do a quick 'deep diff' to catch high-level changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd65ac75-8e52-4e12-ba48-15e37354c1e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Manual json path checks\n",
+    "\n",
+    "old_av, new_av = load_json_from_path(os.path.join(ANNOTATIONS_PATH, 'av_train.json')), load_json_from_path('av_train_height-540.json')\n",
+    "f = lambda x: x['videos'][0]['clips'][0]['persons'][1]['tracking_paths'][0]['track'][0]\n",
+    "\n",
+    "print(old_av['videos'][0]['video_uid'])\n",
+    "print(f(old_av), \"\\n\", f(new_av))\n",
+    "# len(old_av['videos'][0]['clips'][0]['persons'][0]['tracking_paths'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10f7fbfa-156a-4ff2-be74-5f59b175d783",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Deepdiffs\n",
+    "# 'No change' results are not reliable when using the max_diffs arg. 'Changed' results are.\n",
+    "# max_diffs arg is usually required to finish diffing in a reasonable amount of time\n",
+    "\n",
+    "from deepdiff import DeepDiff\n",
+    "from pprint import pprint, pformat\n",
+    "\n",
+    "def print_json_file_diff(a, b, print_limit=5000):\n",
+    "    print(f\"loading {a}, {b}...\")\n",
+    "    obj_a, obj_b = load_json_from_path(a), load_json_from_path(b)\n",
+    "    print(\"diffing...\")\n",
+    "    x = DeepDiff(obj_a, obj_b, max_diffs=500)\n",
+    "    print(\"pformatting...\")\n",
+    "    y = pformat(x)\n",
+    "    print(\"printing...\")\n",
+    "    print(y[:print_limit])\n",
+    "    \n",
+    "for j in transform_jobs:\n",
+    "    print_json_file_diff(os.path.join(ANNOTATIONS_PATH, j[0]), j[1])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added a jupyter notebook to create new versions of the annotations. Also added deepdiff to requirements.txt and .DS_Store to .gitignore.

Transforming an annotation file with this notebook means writing a list of `Transforms` to apply, then applying them.

Transforms have type: `(selector: (obj: any, context: dict) -> bool, mapper: (obj: any, context: dict) -> any)`
Whenever we see a 'context field,' it's added to the context dictionary and propagated to children. This lets us use video and clip uids in child objects.

Selectors get a json object and our context. They output a bool for whether this Transform applies to this object. If it does, we replace the object with mapper(object, context).

The notebook shows an e2e Transform example to generate annotation files with scaled-down bounding boxes.