### PR TITLE
Replace local viz with hosted vis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ EGO4D is the world's largest egocentric (first person) video ML dataset and benc
 
 Public Documentation/Start Here: [Ego4D Docs](https://ego4d-data.org/docs/start-here/)
 
+Explore the dataset here (you'll need a license): [Ego4D Visualizer](https://visualize.ego4d-data.org/)
+
 For the CLI readme (to download/access): [CLI README](ego4d/cli/README.md)
 
 For a demo notebook: [Annotation Notebook](notebooks/annotation_visualization.ipynb)
-
-For the visualization engine: [Viz README](viz/narrations/README.md)
 
 For feature extraction: [Feature README](ego4d/features/README.md)
 


### PR DESCRIPTION
as title - the local version lacks a LOT of features compared to the hosted, so there are very few reasons to use the local version instead of the hosted vis tool.