### PR TITLE
add sfu + unc to university bucket list

### DIFF
--- a/ego4d/cli/universities.py
+++ b/ego4d/cli/universities.py
@@ -14,6 +14,8 @@ UNIV_TO_BUCKET = {
     "kaust": "ego4d-kaust",
     "minnesota": "ego4d-minnesota",
     "nus": "ego4d-speac",
+    "sfu": "ego4d-sfu",
+    "unc": "ego4d-unc",
     "unict": "ego4d-unict-milan",
     "utokyo": "ego4d-utokyo",
     "uniandes": "ego4d-university-sa",


### PR DESCRIPTION
Adds placeholder s3 buckets for SFU and UNC for internal code use and in preparation for when those buckets are created.