### PR TITLE
Fix pyark import

### DIFF
--- a/ego4d/internal/human_pose/camera.py
+++ b/ego4d/internal/human_pose/camera.py
@@ -203,20 +203,20 @@ def ximage_to_yimage(pt_img: Vec2, from_cam: Camera, to_cam: Camera, z: float = 
 
 
 def get_aria_camera_models(aria_path):
-    import pyark.datatools as datatools  # slow import?
+    import projectaria_tools
 
-    vrs_data_provider = datatools.dataprovider.AriaVrsDataProvider()
+    vrs_data_provider = projectaria_tools.dataprovider.AriaVrsDataProvider()
     vrs_data_provider.openFile(aria_path)
 
-    aria_stream_id = datatools.dataprovider.StreamId(214, 1)
+    aria_stream_id = projectaria_tools.dataprovider.StreamId(214, 1)
     vrs_data_provider.setStreamPlayer(aria_stream_id)
     vrs_data_provider.readFirstConfigurationRecord(aria_stream_id)
 
-    aria_stream_id = datatools.dataprovider.StreamId(1201, 1)
+    aria_stream_id = projectaria_tools.dataprovider.StreamId(1201, 1)
     vrs_data_provider.setStreamPlayer(aria_stream_id)
     vrs_data_provider.readFirstConfigurationRecord(aria_stream_id)
 
-    aria_stream_id = datatools.dataprovider.StreamId(1201, 2)
+    aria_stream_id = projectaria_tools.dataprovider.StreamId(1201, 2)
     vrs_data_provider.setStreamPlayer(aria_stream_id)
     vrs_data_provider.readFirstConfigurationRecord(aria_stream_id)
 

--- a/ego4d/internal/human_pose/scripts/_install/conda.sh
+++ b/ego4d/internal/human_pose/scripts/_install/conda.sh
@@ -25,7 +25,7 @@ cd ../..
 
 cd mmlab/mmpose
 pip install -r requirements.txt
-pip install -v -e . 
+pip install -v -e .
 pip install flask
 pip install timm==0.4.9
 cd ../..
@@ -45,7 +45,7 @@ pip install python-fcl
 pip install hydra-core --upgrade
 pip install av iopath
 pip install pycolmap
-pip install pyark
+pip install projectaria_tools
 
 ##-----------------------------------------------
 ## install ego4d locally


### PR DESCRIPTION
Summary: Looks like Aria recently changed their package name from `pyark` to `projectaria_tools` and the `pyark` name is taken by another unrelated package. Replacing it with `pip install projectaria_tools` and use `projectaria_tools` instead seems to work.

Differential Revision: D46574133

