### PR TITLE
Fix configs and allow saving visualization videos from different steps simultaneously

### DIFF
--- a/ego4d/internal/human_pose/configs/cmu_soccer_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/cmu_soccer_rawal.yaml
@@ -1,4 +1,5 @@
-root_dir: "/home/rawalk/Desktop/datasets/ego4d_data"
+repo_root_dir: null
+data_dir: "/home/rawalk/Desktop/datasets/ego4d_data"
 
 gpu_id: 0
 
@@ -27,19 +28,19 @@ mode_preprocess:
   extract_all_aria_frames: false
 
 mode_bbox:
-  detector_config: "/home/rawalk/Desktop/forked_ego4d/ego4d/internal/human_pose/external/mmlab/mmpose/demo/mmdetection_cfg/faster_rcnn_x101_64x4d_fpn_mstrain_3x_coco.py"
+  detector_config: "ego4d/internal/human_pose/external/mmlab/mmpose/demo/mmdetection_cfg/faster_rcnn_x101_64x4d_fpn_mstrain_3x_coco.py"
   detector_checkpoint: 'https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_x101_64x4d_fpn_mstrain_3x_coco/faster_rcnn_x101_64x4d_fpn_mstrain_3x_coco_20210524_124528-26c63de6.pth'
   use_aria_trajectory: true
   human_height: 1.5
+  human_radius: 0.3
+  min_bbox_score: 0.7
 
 mode_pose2d:
-  pose_config: "/home/rawalk/Desktop/forked_ego4d/ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"
+  pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"
   pose_checkpoint: "https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth"
-  dummy_pose_config: '/home/rawalk/Desktop/forked_ego4d/ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py'
+  dummy_pose_config: 'ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py'
   dummy_pose_checkpoint: 'https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192-c78dce93_20200708.pth'
 
 mode_pose3d:
-  todo: abc
-
-mode_multi_view_vis:
-  todo: abc
+  start_frame: 0
+  end_frame: -1

--- a/ego4d/internal/human_pose/configs/iu_bike_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/iu_bike_rawal.yaml
@@ -38,7 +38,7 @@ mode_bbox:
 
 mode_pose2d:
   pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/ViTPose_huge_coco_256x192.py"
-  pose_checkpoint: 'vitpose/checkpoints/vitpose-h-multi-coco.pth'
+  pose_checkpoint: "https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth"
 
   dummy_pose_config: 'ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py'
   dummy_pose_checkpoint: 'https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192-c78dce93_20200708.pth'

--- a/ego4d/internal/human_pose/configs/iu_music_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/iu_music_rawal.yaml
@@ -32,9 +32,15 @@ mode_bbox:
   detector_checkpoint: 'https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_x101_64x4d_fpn_mstrain_3x_coco/faster_rcnn_x101_64x4d_fpn_mstrain_3x_coco_20210524_124528-26c63de6.pth'
   use_aria_trajectory: true
   human_height: 0.6
+  human_radius: 0.3
+  min_bbox_score: 0.7
 
 mode_pose2d:
   pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"
   pose_checkpoint: "https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth"
   dummy_pose_config: 'ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py'
   dummy_pose_checkpoint: 'https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192-c78dce93_20200708.pth'
+
+mode_pose3d:
+  start_frame: 0
+  end_frame: -1

--- a/ego4d/internal/human_pose/pose_refiner.py
+++ b/ego4d/internal/human_pose/pose_refiner.py
@@ -1,19 +1,12 @@
-import os
-import pathlib
-import sys
 from typing import List
 
-import cv2
-import mmcv
 import numpy as np
 import torch
+
+from ego4d.internal.human_pose.utils import COCO_SKELETON, COCO_SKELETON_FLIP_PAIRS
 from mmcv.runner import build_optimizer
-from tqdm import tqdm
-
-from utils import COCO_SKELETON, COCO_SKELETON_FLIP_PAIRS
 
 
-###----------------------------------------------------------------------------
 class OptimizableParameters:
     """Collects parameters for optimization."""
 

--- a/ego4d/internal/human_pose/postprocess_pose3d.py
+++ b/ego4d/internal/human_pose/postprocess_pose3d.py
@@ -1,11 +1,6 @@
-import os
-import random
-
-import cv2
 import numpy as np
 import pandas as pd
 from scipy import signal
-from scipy.optimize import least_squares
 
 ## for coco 17 keypoints
 ## https://github.com/open-mmlab/mmpose/blob/af2cacd8492bea3b18d7eb407c5b9e52af1ad2fb/mmpose/apis/inference.py#L593
@@ -31,7 +26,7 @@ COCO_SKELETON = {
     "right_neck": [4, 6],  ## r-ear to r-shldr
 }
 
-##------------------------------------------------------------------------------------
+
 def detect_outliers_and_interpolate(poses):
     refine_poses = poses.copy()
     refine_poses = fill_missing_keypoints(
@@ -159,6 +154,12 @@ def fill_missing_keypoints(poses, window_length=10, polyorder=3):
         missing_timestamps = ((conf == 0).nonzero())[0]
 
         if len(missing_timestamps) == 0:
+            continue
+
+        if len(missing_timestamps) == total_time:
+            print(
+                f"[Warning] The keypoint {i} is consistently missing, skip interpolation!"
+            )
             continue
 
         ##----replace the missing keypoints with nan------------

--- a/ego4d/internal/human_pose/triangulator.py
+++ b/ego4d/internal/human_pose/triangulator.py
@@ -3,10 +3,10 @@ import random
 import numpy as np
 
 import torch
+from ego4d.internal.human_pose.utils import COCO_KP_ORDER
 from scipy.optimize import least_squares
-from utils import COCO_KP_ORDER
 
-##------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
 ## performs triangulation
 class Triangulator:
     def __init__(self, time_stamp, camera_names, cameras, multiview_pose2d):
@@ -72,7 +72,7 @@ class Triangulator:
                     confidence = self.pose2d[human_name][camera_name][keypoint_idx, 2]
                     camera = self.cameras[camera_name]
 
-                    ##---------use high confidence predictions------------------
+                    # ---------use high confidence predictions------------------
                     if confidence > self.keypoint_thres:
                         extrinsics = camera.extrinsics[:3, :]  ## 3x4
 
@@ -90,7 +90,7 @@ class Triangulator:
                             camera_name
                         )  ## camera choosen for triangulation for this point
 
-                ##---------------------------------------------------------------------------------------------
+                # ---------------------------------------------------------------------------------------------
                 if len(points) >= self.min_views:
                     ## triangulate for a single point
                     (
@@ -105,22 +105,25 @@ class Triangulator:
                         direct_optimization=True,
                     )
 
-                    if debug == True:
+                    if debug:
                         print(
-                            "kps_idx:{} kps_name:{} kps_error:{}, inliers:{}, {}".format(
-                                keypoint_idx,
-                                COCO_KP_ORDER[keypoint_idx],
-                                reprojection_error_vector.mean(),
-                                len(inlier_views),
-                                [choosen_cameras[index] for index in inlier_views],
+                            " ".join(
+                                [
+                                    f"ts:{self.time_stamp}",
+                                    f"kp_idx:{keypoint_idx}",
+                                    f"kp_name:{COCO_KP_ORDER[keypoint_idx]}",
+                                    f"kps_error:{reprojection_error_vector.mean():.5f}"
+                                    f"inliers:{len(inlier_views)}",
+                                    f"{[choosen_cameras[index] for index in inlier_views]}",
+                                ]
                             )
                         )
                     error += reprojection_error_vector.mean()
 
                     points_3d[human_name][keypoint_idx, :3] = point_3d
-                    points_3d[human_name][keypoint_idx, 3] = 1  ## mark as valid
+                    points_3d[human_name][keypoint_idx, 3] = 1  # mark as valid
 
-            if debug == True:
+            if debug:
                 print("{}, error:{}".format(human_name, error))
 
         return points_3d["aria01"]

--- a/ego4d/internal/utils/launch_utils.py
+++ b/ego4d/internal/utils/launch_utils.py
@@ -134,7 +134,8 @@ def launch_job(task, args):
         )
 
         job = executor.submit(task.main, args)
-        print(f"Job id: j{job.job_id}")
+        # print out job id and working dir for record
+        print(f"j{job.job_id}={args.work_dir}")
     elif args.run_type in ["flow_canary", "flow_canary_rebuild", "flow_local"]:
         args_json = os.path.join(args.work_dir, "flow_args.json")
 


### PR DESCRIPTION
Summary:
- Fixed the configs for cmu_soccer_rawal, iu_bike_rawal and iu_music_rawal using the default fields (referring to unc_T1_rawal) so that we could run the body pose gt extraction on these data.
- Ensure pose3d_dir is created
- Fix the confusion between data_dir and root_dir
- Allow saving multiple visualization videos by varying the output mp4 names. They are all saved to the same folder ctx.vis_pose3d_dir with different names for easy inspection.
- The steps are ordered so that visualization of the previous steps could be carried out before certain step, e.g., refine_pose3d, failed.

Note that for these new scenarios the body pose extraction is not that robust yet (see the examples in the test plan), and the last step refine_pose3d could crash due to no keypoints being detected.

Differential Revision: D47306350

