### PR TITLE
Support min_area_ratio in config

### DIFF
--- a/ego4d/internal/human_pose/configs/cmu_soccer_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/cmu_soccer_rawal.yaml
@@ -34,6 +34,7 @@ mode_bbox:
   human_height: 1.5
   human_radius: 0.3
   min_bbox_score: 0.7
+  min_area_ratio: 0.002
 
 mode_pose2d:
   pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"

--- a/ego4d/internal/human_pose/configs/iu_bike_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/iu_bike_rawal.yaml
@@ -35,9 +35,10 @@ mode_bbox:
   human_height: 1.5
   human_radius: 0.3
   min_bbox_score: 0.7
+  min_area_ratio: 0.005
 
 mode_pose2d:
-  pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/ViTPose_huge_coco_256x192.py"
+  pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"
   pose_checkpoint: "https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth"
 
   dummy_pose_config: 'ego4d/internal/human_pose/external/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py'

--- a/ego4d/internal/human_pose/configs/iu_music_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/iu_music_rawal.yaml
@@ -34,6 +34,7 @@ mode_bbox:
   human_height: 0.6
   human_radius: 0.3
   min_bbox_score: 0.7
+  min_area_ratio: 0.005
 
 mode_pose2d:
   pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"

--- a/ego4d/internal/human_pose/configs/unc_T1_rawal.yaml
+++ b/ego4d/internal/human_pose/configs/unc_T1_rawal.yaml
@@ -35,6 +35,7 @@ mode_bbox:
   human_height: 1.5
   human_radius: 0.3
   min_bbox_score: 0.7
+  min_area_ratio: 0.005
 
 mode_pose2d:
   pose_config: "ego4d/internal/human_pose/external/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -89,8 +89,8 @@ def _create_json_from_capture_dir(capture_dir: Optional[str]) -> Dict[str, Any]:
         capture_dir = capture_dir[0:-1]
 
     if capture_dir.startswith("s3://"):
-        # bucket_name = capture_dir.split("s3://")[1].split("/")[0]
-        prefix_path = "s3://{bucket_name}"
+        bucket_name = capture_dir.split("s3://")[1].split("/")[0]
+        prefix_path = f"s3://{bucket_name}"
     else:
         prefix_path = capture_dir
 
@@ -558,6 +558,7 @@ def mode_bbox(config: Config):
                 proposal_points_2d,
                 exo_camera.camera_model.width,
                 exo_camera.camera_model.height,
+                min_area_ratio=config.mode_bbox.min_area_ratio,
             )
 
             bbox_xyxy = None
@@ -875,7 +876,7 @@ def multi_view_vis(ctx, camera_names, read_dir, write_dir, write_video):
         cv2.imwrite(os.path.join(write_dir, image_name), canvas)
 
     # ----------make video--------------
-    command = "rm -rf {}/exo.mp4".format(write_dir)
+    command = f"rm -rf {write_video}"
     os.system(command)
 
     command = "ffmpeg -r {} -f image2 -i {}/%05d.jpg -pix_fmt yuv420p {}".format(

--- a/ego4d/internal/human_pose/main_single_camera.py
+++ b/ego4d/internal/human_pose/main_single_camera.py
@@ -303,6 +303,7 @@ def mode_bbox(config: Config, camera_name: str):
                 proposal_points_2d,
                 exo_camera.camera_model.width,
                 exo_camera.camera_model.height,
+                min_area_ratio=config.mode_bbox.min_area_ratio,
             )
 
             bbox_xyxy = None

--- a/ego4d/internal/human_pose/triangulator.py
+++ b/ego4d/internal/human_pose/triangulator.py
@@ -112,7 +112,7 @@ class Triangulator:
                                     f"ts:{self.time_stamp}",
                                     f"kp_idx:{keypoint_idx}",
                                     f"kp_name:{COCO_KP_ORDER[keypoint_idx]}",
-                                    f"kps_error:{reprojection_error_vector.mean():.5f}"
+                                    f"kps_error:{reprojection_error_vector.mean():.5f}",
                                     f"inliers:{len(inlier_views)}",
                                     f"{[choosen_cameras[index] for index in inlier_views]}",
                                 ]

--- a/ego4d/internal/human_pose/utils.py
+++ b/ego4d/internal/human_pose/utils.py
@@ -10,7 +10,7 @@ def check_and_convert_bbox(
     bbox_2d_all,
     image_width,
     image_height,
-    bbox_thres=0.005,
+    min_area_ratio=0.005,
     max_aspect_ratio_thres=5.0,
     min_aspect_ratio_thres=0.5,
 ):
@@ -40,7 +40,7 @@ def check_and_convert_bbox(
     bbox_area_ratio = area * 1.0 / image_area
 
     ## if bbox is too small
-    if bbox_area_ratio < bbox_thres:
+    if bbox_area_ratio < min_area_ratio:
         return None
 
     aspect_ratio = bbox_height / bbox_width  ## height/width


### PR DESCRIPTION
Summary:
- Support min_area_ratio in config

```
batch_job_name=egobodypose_gt_gen
cfg=cmu_soccer_rawal
frame_start=7000
frame_end=7200
data_dir=/checkpoint/$USER/datasets/EgoExoPose/tmp_${frame_start}_${frame_end}
partition=learnaccel
run_type=submitit
steps=preprocess+bbox+pose2d+pose3d+multi_view_vis_bbox+multi_view_vis_pose2d+multi_view_vis_pose3d+refine_pose3d+multi_view_vis_refine_pose3d

python launch_main.py \
--batch_job_name ${batch_job_name} \
--config-name ${cfg} \
--partition ${partition} \
--run_type ${run_type} \
--steps ${steps} \
data_dir=${data_dir} \
inputs.from_frame_number=${frame_start} \
inputs.to_frame_number=${frame_end} \
mode_preprocess.vrs_bin_path=/private/home/jinghuang/code/vrs/build/tools/vrs/vrs \
repo_root_dir=/private/home/${USER}/code/Ego4d
```

Before the change, the person in certain views of the cmu_soccer scene would get filtered due to the bbox being too small w.r.t. the image area. Reducing this threshold from 0.005 to 0.002 makes the person detectable without introducing extra noises.

- Allow overwriting previous visualizing vidoes
- Fixed weight/config mismatch in iu_bike

Differential Revision: D47459319

