### PR TITLE
Support dev_release data

### DIFF
--- a/ego4d/internal/colmap/preprocess.py
+++ b/ego4d/internal/colmap/preprocess.py
@@ -151,9 +151,12 @@ def download_andor_generate_streams(
 ) -> Dict[str, Any]:
     os.makedirs(output_dir, exist_ok=True)
     if metadata["timesync_csv_path"] is not None:
-        _download_s3_path(
-            metadata["timesync_csv_path"], os.path.join(output_dir, "timesync.csv")
-        )
+        local_timesync_csv = os.path.join(output_dir, "timesync.csv")
+        if metadata["timesync_csv_path"].startswith("s3://"):
+            _download_s3_path(metadata["timesync_csv_path"], local_timesync_csv)
+        else:
+            # local path
+            shutil.copy2(metadata["timesync_csv_path"], local_timesync_csv)
 
     by_dev_id = {}
     for v in tqdm(metadata["videos"]):

--- a/ego4d/internal/human_pose/config.py
+++ b/ego4d/internal/human_pose/config.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 class Input:
     from_frame_number: int
     to_frame_number: int
+    take_name: Optional[str]
     take_uid: Optional[str]
     capture_root_dir: Optional[str]
     metadata_json_path: Optional[str]
@@ -32,6 +33,7 @@ class BBoxConfig:
     human_height: float
     human_radius: float
     min_bbox_score: float
+    min_area_ratio: float
 
 
 @dataclass

--- a/ego4d/internal/human_pose/configs/dev_release_base.yaml
+++ b/ego4d/internal/human_pose/configs/dev_release_base.yaml
@@ -7,7 +7,8 @@ mode: "preprocess"
 inputs:
   from_frame_number: 0
   to_frame_number: null
-  take_uid: "547322d7-399d-4aa8-af08-0a209b348aaa"
+  take_name: "uniandes_dance_007_3"
+  take_uid: null
   metadata_json_path: null
   aria_trajectory_path: null
   exo_trajectory_path: null
@@ -29,6 +30,7 @@ mode_bbox:
   human_height: 1.5
   human_radius: 0.3
   min_bbox_score: 0.7
+  min_area_ratio: 0.005
 mode_pose2d:
   pose_config: "tp/mmlab/mmpose/configs/wholebody/2d_kpt_sview_rgb_img/topdown_heatmap/coco-wholebody/hrnet_w48_coco_wholebody_384x288_dark_plus.py"
   pose_checkpoint: "https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth"


### PR DESCRIPTION
Summary:
- Backward compatibility with different versions of projectaria_tools (especially the version installed with `pip install projectaria_tools`)
- Use take_name instead of take_uid for human-readability of which take to run the pipeline on.
- Use `cache_root_dir` instead of `data_dir` for frames since they are stored in different locations
- Support rendering up to 6 cameras (previous max=4; could be further extended to more if necessary)

Differential Revision: D47504726

