### PR TITLE
Fix cylinder filter for body bbox

### DIFF
--- a/ego4d/internal/human_pose/bbox_detector.py
+++ b/ego4d/internal/human_pose/bbox_detector.py
@@ -33,8 +33,6 @@ class DetectorModel:
 
     ## iou_threshold: the threshold to decide whether to use the offshelf bbox or not
     def get_bboxes(self, image_name, bboxes, iou_threshold=0.3):
-        refined_bboxes = bboxes.copy()
-
         det_results = inference_detector(self.detector, image_name)
         person_results = process_mmdet_results(
             det_results, 1

--- a/ego4d/internal/human_pose/camera.py
+++ b/ego4d/internal/human_pose/camera.py
@@ -90,7 +90,7 @@ def create_camera_data(
     device_row_key: str,
 ) -> Dict[str, Any]:
     if camera_model is None:
-        assert "cam" in name
+        assert "cam" in name or "gp" in name, f"Unrecognized camera name: {name}"
         T_device_camera = np.eye(4)
         T_camera_device = np.eye(4)
         camera_model = _create_exo_camera(device_row)

--- a/ego4d/internal/human_pose/configs/dev_release_base.yaml
+++ b/ego4d/internal/human_pose/configs/dev_release_base.yaml
@@ -36,6 +36,8 @@ mode_pose2d:
   pose_checkpoint: "https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth"
   dummy_pose_config: 'tp/mmlab/mmpose/configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w32_coco_256x192.py'
   dummy_pose_checkpoint: 'https://download.openmmlab.com/mmpose/top_down/hrnet/hrnet_w32_coco_256x192-c78dce93_20200708.pth'
+  hand_pose_config: 'tp/mmlab/mmpose/configs/hand/2d_kpt_sview_rgb_img/topdown_heatmap/coco_wholebody_hand/hrnetv2_w18_coco_wholebody_hand_256x256_dark.py'
+  hand_pose_ckpt: 'https://download.openmmlab.com/mmpose/hand/dark/hrnetv2_w18_coco_wholebody_hand_256x256_dark-a9228c9c_20210908.pth'
 mode_pose3d:
   start_frame: 0
   end_frame: -1

--- a/ego4d/internal/human_pose/utils.py
+++ b/ego4d/internal/human_pose/utils.py
@@ -147,7 +147,13 @@ def get_region_proposal(
 
     mesh = trimesh.primitives.Cylinder(radius=radius, height=human_height)
     mesh.apply_transform(transform)
-    bbox_3d = mesh.vertices  ## slower but smoother, all the vertices of the cylinder
+
+    # Note: using all vertices of the cylinder (bbox_3d = mesh.vertices) is not enough
+    # since the bottom could be easily out of the image boundary and
+    # the proposal filter would shrink to just the top of the cylinder
+    # Therefore, we do a uniform sampling around the whole cylinder instead
+    bbox_3d, _face_index = trimesh.sample.sample_surface_even(mesh, count=100)
+
     return bbox_3d
 
 


### PR DESCRIPTION
Summary:
- Fix cylinder filter for body bbox using uniform sampling (`trimesh.sample.sample_surface_even`)
- Support hand pose config in `dev_release_base.yaml`
- Allow `gp` in exo camera name
- Standardize saving path using `skel_type` (`body` or `hand`)
- Use `ctx.cache_root_dir` instead of `ctx.data_dir` since they could be different paths and `data_dir` could be read-only
- Partially support non-standard aria file names such as `aria02` (full support will be introduced later)

Differential Revision: D47939163

