### PR TITLE
Simplified aria camera model projection & unprojection

### DIFF
--- a/ego4d/internal/human_pose/camera.py
+++ b/ego4d/internal/human_pose/camera.py
@@ -144,7 +144,10 @@ def create_camera_data(
 
 
 def xdevice_to_ximage(pt_device: Vec3, cam: Camera):
-    if cam.camera_type in ("aria", "colmap"):
+    if cam.camera_type == "aria":
+        assert cam.camera_model is not None
+        ret = cam.camera_model.project_no_checks(pt_device / pt_device[2])
+    elif cam.camera_type == "colmap":
         assert cam.camera_model is not None
         ret = cam.camera_model.world_to_image(pt_device[0:2] / pt_device[2])
     else:
@@ -155,7 +158,7 @@ def xdevice_to_ximage(pt_device: Vec3, cam: Camera):
 def ximage_to_xdevice(pt_img: Vec2, cam: Camera):
     if cam.camera_type == "aria":
         assert cam.camera_model is not None
-        ret = cam.camera_model.projectionModel.unproject(pt_img)
+        ret = cam.camera_model.unproject_no_checks(pt_img)[:2]
     elif cam.camera_type == "colmap":
         assert cam.camera_model is not None
         ret = cam.camera_model.image_to_world(pt_img)

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -94,21 +94,6 @@ class Context:
     frame_rel_dir: str = None
 
 
-class aria_camera_model:
-    def __init__(self, camera_name, camera_model):
-        self.camera_name = camera_name
-        self.camera_model = camera_model
-
-    def image_to_world(self, point_2d):
-        # return self.camera_model.projectionModel.unproject(point_2d)[:2] # Legacy aria model
-        return self.camera_model.unproject_no_checks(point_2d)[:2]
-
-    def world_to_image(self, pt):
-        pt_padded = np.append(pt, 1)
-        # return self.camera_model.projectionModel.project(pt_padded) # Legacy aria model
-        return self.camera_model.project_no_checks(pt_padded)
-
-
 def _create_json_from_capture_dir(capture_dir: Optional[str]) -> Dict[str, Any]:
     assert capture_dir is not None
 
@@ -1423,11 +1408,9 @@ def mode_ego_hand_pose2d(config: Config):
         image = cv2.imread(image_path)
 
         # Create aria camera at this timestamp
-        ari_calib_model = aria_camera_model(
-            ego_cam_name, aria_camera_models[stream_name_to_id[ego_cam_name]]
-        )
         aria_camera = create_camera(
-            dset[time_stamp][ego_cam_name]["camera_data"], ari_calib_model
+            dset[time_stamp][ego_cam_name]["camera_data"],
+            aria_camera_models[stream_name_to_id[ego_cam_name]],
         )
 
         ########################## Hand bbox from re-projected wholebody-Hand kpts ############################
@@ -1761,11 +1744,9 @@ def mode_egoexo_hand_pose3d(config: Config):
 
         # Add ego camera
         ########################## Add Aria calibration model ###############################
-        ari_calib_model = aria_camera_model(
-            ego_cam_name, aria_camera_models[stream_name_to_id[ego_cam_name]]
-        )
         aria_exo_cameras[ego_cam_name] = create_camera(
-            info[ego_cam_name]["camera_data"], ari_calib_model
+            info[ego_cam_name]["camera_data"],
+            aria_camera_models[stream_name_to_id[ego_cam_name]],
         )
         #####################################################################################
 

--- a/ego4d/internal/human_pose/triangulator.py
+++ b/ego4d/internal/human_pose/triangulator.py
@@ -3,6 +3,7 @@ import random
 
 import numpy as np
 import torch
+from ego4d.internal.human_pose.camera import ximage_to_xdevice
 from ego4d.internal.human_pose.utils import COCO_KP_ORDER
 from scipy.optimize import least_squares
 
@@ -82,7 +83,7 @@ class Triangulator:
 
                         ## get the ray in 3D
 
-                        ray_3d = camera.camera_model.image_to_world(point_2d)  ## 1 x 2
+                        ray_3d = ximage_to_xdevice(point_2d, camera)  ## 1 x 2
                         ray_3d = np.append(ray_3d, 1)
 
                         assert len(ray_3d) == 3


### PR DESCRIPTION
Removed `aria_camera_model` class in main.py to simplify the projection & unprojection for aria camera model. 