### PR TITLE
Save reprojection error in hand pose3d triangulation

### DIFF
--- a/ego4d/internal/human_pose/camera.py
+++ b/ego4d/internal/human_pose/camera.py
@@ -144,7 +144,10 @@ def create_camera_data(
 
 
 def xdevice_to_ximage(pt_device: Vec3, cam: Camera):
-    if cam.camera_type in ("aria", "colmap"):
+    if cam.camera_type == "aria":
+        assert cam.camera_model is not None
+        ret = cam.camera_model.project_no_checks(pt_device / pt_device[2])
+    elif cam.camera_type == "colmap":
         assert cam.camera_model is not None
         ret = cam.camera_model.world_to_image(pt_device[0:2] / pt_device[2])
     else:
@@ -155,7 +158,7 @@ def xdevice_to_ximage(pt_device: Vec3, cam: Camera):
 def ximage_to_xdevice(pt_img: Vec2, cam: Camera):
     if cam.camera_type == "aria":
         assert cam.camera_model is not None
-        ret = cam.camera_model.projectionModel.unproject(pt_img)
+        ret = cam.camera_model.unproject_no_checks(pt_img)[:2]
     elif cam.camera_type == "colmap":
         assert cam.camera_model is not None
         ret = cam.camera_model.image_to_world(pt_img)
@@ -194,7 +197,7 @@ def batch_xworld_to_yimage_check_camera_z(pts3d: Vec3, to_cam: Camera):
         pt_target = np.matmul(T_to_world, np.array(pt3d.tolist() + [1.0]))[0:3]
         # For negative z-coor point, assign (-1,-1) as image coordinate (which will be filtered out later)
         if pt_target[-1] < 0:
-            pts2d.append(np.array([[-1,-1]]))
+            pts2d.append(np.array([[-1, -1]]))
         else:
             pts2d.append(xdevice_to_ximage(pt_target, to_cam).reshape(1, -1))
     pts2d = np.concatenate(pts2d, axis=0)

--- a/ego4d/internal/human_pose/camera.py
+++ b/ego4d/internal/human_pose/camera.py
@@ -184,6 +184,23 @@ def batch_xworld_to_yimage(pts3d: Vec3, to_cam: Camera):
     return pts2d
 
 
+def batch_xworld_to_yimage_check_camera_z(pts3d: Vec3, to_cam: Camera):
+    assert pts3d.shape[1] == 3
+    pts2d = []
+
+    # TODO: optimize
+    for pt3d in pts3d:
+        T_to_world = to_cam.extrinsics
+        pt_target = np.matmul(T_to_world, np.array(pt3d.tolist() + [1.0]))[0:3]
+        # For negative z-coor point, assign (-1,-1) as image coordinate (which will be filtered out later)
+        if pt_target[-1] < 0:
+            pts2d.append(np.array([[-1,-1]]))
+        else:
+            pts2d.append(xdevice_to_ximage(pt_target, to_cam).reshape(1, -1))
+    pts2d = np.concatenate(pts2d, axis=0)
+    return pts2d
+
+
 def xdevice_to_yimage(pt3d: Vec3, from_cam: Camera, to_cam: Camera):
     assert pt3d.shape[0] == 3
     print(to_cam.T_device_camera)

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -1636,6 +1636,7 @@ def mode_exo_hand_pose3d(config: Config):
             multi_view_pose2d,
             keypoint_thres=tri_threshold,
             num_keypoints=42,
+            inlier_reproj_error_check=True,
         )
         pose3d = triangulator.run(debug=False)  ## N x 4 (x, y, z, confidence)
         poses3d[time_stamp] = pose3d
@@ -1820,6 +1821,7 @@ def mode_egoexo_hand_pose3d(config: Config):
             multi_view_pose2d,
             keypoint_thres=tri_threshold,
             num_keypoints=42,
+            inlier_reproj_error_check=True
         )
         pose3d = triangulator.run(debug=False)  ## N x 4 (x, y, z, confidence)
         poses3d[time_stamp] = pose3d

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -20,6 +20,7 @@ from ego4d.internal.colmap.preprocess import download_andor_generate_streams
 from ego4d.internal.human_pose.bbox_detector import DetectorModel
 from ego4d.internal.human_pose.camera import (
     batch_xworld_to_yimage,
+    batch_xworld_to_yimage_check_camera_z,
     create_camera,
     create_camera_data,
     get_aria_camera_models,
@@ -1439,7 +1440,7 @@ def mode_ego_hand_pose2d(config: Config):
         ########################## Hand bbox from re-projected wholebody-Hand kpts ############################
         # Project wholebody-Hand pose3d kpts onto current aria image plane
         pose3d = wholebodyHand_pose3d[time_stamp]
-        projected_pose3d = batch_xworld_to_yimage(pose3d[:, :3], aria_camera)
+        projected_pose3d = batch_xworld_to_yimage_check_camera_z(pose3d[:, :3], aria_camera)
         projected_pose3d = np.concatenate(
             [projected_pose3d, pose3d[:, 3].reshape(-1, 1)], axis=1
         )

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -1186,7 +1186,7 @@ def mode_exo_hand_pose2d(config: Config):
     ##################################
     exo_cam_names = (
         ctx.exo_cam_names
-    )  # Select all default cameras: ctx.exo_cam_names or manual seelction: ['cam01','cam02']
+    )  # Select all default cameras: ctx.exo_cam_names or manual selction: ['cam01','cam02']
     kpts_vis_threshold = 0.3  # This determines the hand pose2d kpts confidence threshold for visualization
     visualization = True  # Whether show visualization
     ##################################
@@ -1887,7 +1887,7 @@ def mode_egoexo_hand_pose3d(config: Config):
                     [projected_pose3d[:21], projected_pose3d[21:]], image, save_path
                 )
 
-            # Compute reprojection error
+        # Compute reprojection error
         invalid_index = pose3d[:, 2] == 0
         for camera_name in ctx.exo_cam_names + ego_cam_names:
             # Extract projected pose3d results onto current camera plane

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -1594,7 +1594,7 @@ def mode_exo_hand_pose3d(config: Config):
         for exo_camera_name in exo_cam_names:
             curr_exo_hand_pose2d_kpts = exo_poses2d[time_stamp][
                 exo_camera_name
-            ].reshape(-1, 3)
+            ].copy().reshape(-1, 3)
             # Heuristics
             if np.mean(curr_exo_hand_pose2d_kpts[:21, -1]) > 0.3:
                 curr_exo_hand_pose2d_kpts[0, -1] = 1
@@ -1781,7 +1781,7 @@ def mode_egoexo_hand_pose3d(config: Config):
         for exo_camera_name in exo_cam_names:
             curr_exo_hand_pose2d_kpts = exo_poses2d[time_stamp][
                 exo_camera_name
-            ].reshape(-1, 3)
+            ].copy().reshape(-1, 3)
             ### Heuristics: Hardcode hand wrist kpt conf to be 1 if average conf > 0.3 ###
             if np.mean(curr_exo_hand_pose2d_kpts[:21, -1]) > 0.3:
                 curr_exo_hand_pose2d_kpts[0, -1] = 1
@@ -1854,7 +1854,7 @@ def mode_egoexo_hand_pose3d(config: Config):
         if visualization:
             # Visualization of images from all camera views
             for camera_name in ctx.exo_cam_names + ego_cam_names: # Visualize all exo cameras + selected Aria camera
-                img_name_path = camera_name if 'aria' in camera_name or 'slam' in camera_name else f"{camera_name}_0" 
+                img_name_path = camera_name if 'aria' in camera_name else f"{camera_name}_0" 
                 image_path = info[img_name_path]["abs_frame_path"]
                 image = cv2.imread(image_path)
                 curr_camera = aria_exo_cameras[camera_name]
@@ -1868,7 +1868,7 @@ def mode_egoexo_hand_pose3d(config: Config):
                     [projected_pose3d, pose3d[:, 3].reshape(-1, 1)], axis=1
                 )  ## N x 3 (17 for body,; 42 for hand)
 
-                if 'aria' in camera_name or 'slam' in camera_name:
+                if 'aria' in camera_name:
                     projected_pose3d = aria_original_to_extracted(projected_pose3d)
 
                 save_path = os.path.join(vis_pose3d_cam_dir, f"{time_stamp:05d}.jpg")
@@ -1883,10 +1883,10 @@ def mode_egoexo_hand_pose3d(config: Config):
             curr_camera = aria_exo_cameras[camera_name]
             projected_pose3d = batch_xworld_to_yimage(pose3d[:, :3], curr_camera)
             # Rotate projected kpts if is aria camera
-            if 'aria' in camera_name or 'slam' in camera_name:
+            if 'aria' in camera_name:
                     projected_pose3d = aria_original_to_extracted(projected_pose3d)
             # Compute L1-norm between projected 2D kpts and hand_pose2d
-            poses2d = aria_poses2d if 'aria' in camera_name or 'slam' in camera_name else exo_poses2d 
+            poses2d = aria_poses2d if 'aria' in camera_name else exo_poses2d 
             original_pose2d = poses2d[time_stamp][camera_name].reshape(-1,3)[:,:2]
             reprojection_error = np.linalg.norm((original_pose2d-projected_pose3d), ord=1, axis=1)
             # Assign invalid index's reprojection error to be -1

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -1583,8 +1583,10 @@ def mode_exo_hand_pose3d(config: Config):
         exo_poses2d = pickle.load(f)
 
     poses3d = {}
+    reprojection_errors = {}
     for time_stamp in tqdm(range(len(dset)), total=len(dset)):
         info = dset[time_stamp]
+        reprojection_errors[time_stamp] = {}
 
         # # Pose2d estimation from exo camera
         ########### Heuristic Check: Hardcode hand wrist kpt conf to be 1 ################################
@@ -1617,7 +1619,7 @@ def mode_exo_hand_pose3d(config: Config):
                 * left_hand_pos2d_kpts[:, 2]
             )
             # Drop lower kpts result if pairwise_conf_dis is too low
-            if np.mean(pairwise_conf_dis) < 5:
+            if np.mean(pairwise_conf_dis) < 10:
                 right_conf_mean = np.mean(right_hand_pos2d_kpts[:, 2])
                 left_conf_mean = np.mean(left_hand_pos2d_kpts[:, 2])
                 if right_conf_mean < left_conf_mean:
@@ -1661,11 +1663,30 @@ def mode_exo_hand_pose3d(config: Config):
                 hand_pose_model.draw_projected_poses3d(
                     [projected_pose3d[:21], projected_pose3d[21:]], image, save_path
                 )
+        
+        # Compute reprojection error
+        invalid_index = pose3d[:,2] == 0
+        for camera_name in ctx.exo_cam_names:
+            # Extract projected pose3d results onto current camera plane
+            curr_camera = exo_cameras[camera_name]
+            projected_pose3d = batch_xworld_to_yimage(pose3d[:, :3], curr_camera)
+            # Compute L1-norm between projected 2D kpts and hand_pose2d
+            original_pose2d = exo_poses2d[time_stamp][camera_name].reshape(-1,3)[:,:2]
+            reprojection_error = np.linalg.norm((original_pose2d-projected_pose3d), ord=1, axis=1)
+            # Assign invalid index's reprojection error to be -1
+            reprojection_error[invalid_index] = -1
+            # Append result
+            reprojection_errors[time_stamp][camera_name] = reprojection_error.reshape(-1,1)
 
+    # Save pose3d kpts result
     with open(
         os.path.join(pose3d_dir, f"exo_pose3d_triThresh={tri_threshold}.pkl"), "wb"
     ) as f:
         pickle.dump(poses3d, f)
+    # Save reprojection errors
+    with open(os.path.join(pose3d_dir, f"exo_pose3d_triThresh={tri_threshold}_reprojection_error.pkl"), "wb"
+    ) as f:
+        pickle.dump(reprojection_errors, f)
 
 
 def mode_egoexo_hand_pose3d(config: Config):
@@ -1678,7 +1699,8 @@ def mode_egoexo_hand_pose3d(config: Config):
     exo_cam_names = (
         ctx.exo_cam_names
     )  # Select all default cameras: ctx.exo_cam_names or manual seelction: ['cam01','cam02']
-    ego_cam_name = "aria01_rgb"
+    ego_cam_names = ["aria01_rgb"]
+    all_used_cam = exo_cam_names + ego_cam_names
     tri_threshold = 0.3
     visualization = True
     ##########################################
@@ -1742,57 +1764,59 @@ def mode_egoexo_hand_pose3d(config: Config):
     aria_camera_models = get_aria_camera_models(aria_path)
     stream_name_to_id = {
         "aria01_rgb": "214-1",
-        "slam-left": "1201-1",
-        "slam-right": "1201-2",
+        "aria01_slam-left": "1201-1",
+        "aria01_slam-right": "1201-2",
     }
 
     # Iterate through all images and inference
     poses3d = {}
+    reprojection_errors = {}
     for time_stamp in tqdm(range(len(dset)), total=len(dset)):
         info = dset[time_stamp]
+        reprojection_errors[time_stamp] = {}
 
-        ########### Heuristic Check: Hardcode hand wrist kpt conf to be 1 #############
+        # Load hand pose2d results for exo cameras
         multi_view_pose2d = {}
-        # Add exo camera keypoints
+        # 1. Add exo camera keypoints
         for exo_camera_name in exo_cam_names:
             curr_exo_hand_pose2d_kpts = exo_poses2d[time_stamp][
                 exo_camera_name
             ].reshape(-1, 3)
-            # Heuristics
+            ### Heuristics: Hardcode hand wrist kpt conf to be 1 if average conf > 0.3 ###
             if np.mean(curr_exo_hand_pose2d_kpts[:21, -1]) > 0.3:
                 curr_exo_hand_pose2d_kpts[0, -1] = 1
             if np.mean(curr_exo_hand_pose2d_kpts[21:, -1]) > 0.3:
                 curr_exo_hand_pose2d_kpts[21, -1] = 1
             # Append kpts result
             multi_view_pose2d[exo_camera_name] = curr_exo_hand_pose2d_kpts
-        # Add ego camera keypoints (Rotate from extracted view to original view since extri/intri is with original view)
-        ego_hand_pose2d_kpts = aria_extracted_to_original(
-            aria_poses2d[time_stamp].reshape(-1, 3)
-        )
-        # Heuristics
-        if np.mean(ego_hand_pose2d_kpts[:21, -1]) > 0.3:
-            ego_hand_pose2d_kpts[0, -1] = 1
-        if np.mean(ego_hand_pose2d_kpts[21:, -1]) > 0.3:
-            ego_hand_pose2d_kpts[21, -1] = 1
-        # Append kpts result
-        multi_view_pose2d[ego_cam_name] = ego_hand_pose2d_kpts
+        # 2. Add ego camera keypoints (Rotate from extracted view to original view since extri/intri is with original view)
+        for ego_cam_name in ego_cam_names:
+            ego_hand_pose2d_kpts = aria_extracted_to_original(
+                aria_poses2d[time_stamp][ego_cam_name].reshape(-1, 3)
+            )
+            ### Heuristics: Hardcode hand wrist kpt conf to be 1 if average conf > 0.3 ###
+            if np.mean(ego_hand_pose2d_kpts[:21, -1]) > 0.3:
+                ego_hand_pose2d_kpts[0, -1] = 1
+            if np.mean(ego_hand_pose2d_kpts[21:, -1]) > 0.3:
+                ego_hand_pose2d_kpts[21, -1] = 1
+            # Append kpts result
+            multi_view_pose2d[ego_cam_name] = ego_hand_pose2d_kpts
         ###############################################################################
 
         # Add ego camera
-        ########################## Add Aria calibration model ###############################
-        ari_calib_model = aria_camera_model(
-            ego_cam_name, aria_camera_models[stream_name_to_id[ego_cam_name]]
-        )
-        aria_exo_cameras[ego_cam_name] = create_camera(
-            info[ego_cam_name]["camera_data"], ari_calib_model
-        )
-        #####################################################################################
+        for ego_cam_name in ego_cam_names:
+            aria_calib_model = aria_camera_model(
+                ego_cam_name, aria_camera_models[stream_name_to_id[ego_cam_name]]
+            )
+            aria_exo_cameras[ego_cam_name] = create_camera(
+                info[ego_cam_name]["camera_data"], aria_calib_model
+            )
 
         ###### Heuristic Check: If two hands are too close, then drop the one with lower confidence ######
-        for exo_camera_name in exo_cam_names:
+        for curr_cam_name in all_used_cam:
             right_hand_pos2d_kpts, left_hand_pos2d_kpts = (
-                multi_view_pose2d[exo_camera_name][:21, :],
-                multi_view_pose2d[exo_camera_name][21:, :],
+                multi_view_pose2d[curr_cam_name][:21, :],
+                multi_view_pose2d[curr_cam_name][21:, :],
             )
             pairwise_conf_dis = (
                 np.linalg.norm(
@@ -1802,35 +1826,36 @@ def mode_egoexo_hand_pose3d(config: Config):
                 * left_hand_pos2d_kpts[:, 2]
             )
             # Drop lower kpts result if pairwise_conf_dis is too low
-            if np.mean(pairwise_conf_dis) < 5:
+            if np.mean(pairwise_conf_dis) < 10:
                 right_conf_mean = np.mean(right_hand_pos2d_kpts[:, 2])
                 left_conf_mean = np.mean(left_hand_pos2d_kpts[:, 2])
                 if right_conf_mean < left_conf_mean:
                     right_hand_pos2d_kpts[:, :] = 0
                 else:
                     left_hand_pos2d_kpts[:, :] = 0
-            multi_view_pose2d[exo_camera_name][:21] = right_hand_pos2d_kpts
-            multi_view_pose2d[exo_camera_name][21:] = left_hand_pos2d_kpts
+            multi_view_pose2d[curr_cam_name][:21] = right_hand_pos2d_kpts
+            multi_view_pose2d[curr_cam_name][21:] = left_hand_pos2d_kpts
         ###################################################################################################
 
         # triangulate
         triangulator = Triangulator(
             time_stamp,
-            exo_cam_names + [ego_cam_name],
+            all_used_cam,
             aria_exo_cameras,
             multi_view_pose2d,
             keypoint_thres=tri_threshold,
             num_keypoints=42,
-            inlier_reproj_error_check=True
+            inlier_reproj_error_check=True,
         )
         pose3d = triangulator.run(debug=False)  ## N x 4 (x, y, z, confidence)
         poses3d[time_stamp] = pose3d
 
         # visualize pose3d
         if visualization:
-            ### Exo camera visualization ###
-            for camera_name in ctx.exo_cam_names:
-                image_path = info[f"{camera_name}_0"]["abs_frame_path"]
+            # Visualization of images from all camera views
+            for camera_name in ctx.exo_cam_names + ego_cam_names: # Visualize all exo cameras + selected Aria camera
+                img_name_path = camera_name if 'aria' in camera_name or 'slam' in camera_name else f"{camera_name}_0" 
+                image_path = info[img_name_path]["abs_frame_path"]
                 image = cv2.imread(image_path)
                 curr_camera = aria_exo_cameras[camera_name]
 
@@ -1843,38 +1868,41 @@ def mode_egoexo_hand_pose3d(config: Config):
                     [projected_pose3d, pose3d[:, 3].reshape(-1, 1)], axis=1
                 )  ## N x 3 (17 for body,; 42 for hand)
 
+                if 'aria' in camera_name or 'slam' in camera_name:
+                    projected_pose3d = aria_original_to_extracted(projected_pose3d)
+
                 save_path = os.path.join(vis_pose3d_cam_dir, f"{time_stamp:05d}.jpg")
                 hand_pose_model.draw_projected_poses3d(
                     [projected_pose3d[:21], projected_pose3d[21:]], image, save_path
                 )
 
-            ### Ego camera (Aria) visualization ###
-            image_path = dset[time_stamp][ego_cam_name]["abs_frame_path"]
-            image = cv2.imread(image_path)
-            curr_camera = aria_exo_cameras[ego_cam_name]
-            # Directory to store ego camera (aria) visualization
-            vis_pose3d_cam_dir = os.path.join(vis_pose3d_dir, ego_cam_name)
-            if not os.path.exists(vis_pose3d_cam_dir):
-                os.makedirs(vis_pose3d_cam_dir)
-            # Reproject 3D hand kpts onto original aria image plane
+            # Compute reprojection error
+        invalid_index = pose3d[:,2] == 0
+        for camera_name in ctx.exo_cam_names + ego_cam_names:
+            # Extract projected pose3d results onto current camera plane
+            curr_camera = aria_exo_cameras[camera_name]
             projected_pose3d = batch_xworld_to_yimage(pose3d[:, :3], curr_camera)
-            projected_pose3d = np.concatenate(
-                [projected_pose3d, pose3d[:, 3].reshape(-1, 1)], axis=1
-            )  ## N x 3 (17 for body,; 42 for hand)
-            # Rotate from original view to extracted view
-            extracted_projected_pose3d = aria_original_to_extracted(projected_pose3d)
-            # Save visualization result
-            save_path = os.path.join(vis_pose3d_cam_dir, f"{time_stamp:05d}.jpg")
-            hand_pose_model.draw_projected_poses3d(
-                [extracted_projected_pose3d[:21], extracted_projected_pose3d[21:]],
-                image,
-                save_path,
-            )
+            # Rotate projected kpts if is aria camera
+            if 'aria' in camera_name or 'slam' in camera_name:
+                    projected_pose3d = aria_original_to_extracted(projected_pose3d)
+            # Compute L1-norm between projected 2D kpts and hand_pose2d
+            poses2d = aria_poses2d if 'aria' in camera_name or 'slam' in camera_name else exo_poses2d 
+            original_pose2d = poses2d[time_stamp][camera_name].reshape(-1,3)[:,:2]
+            reprojection_error = np.linalg.norm((original_pose2d-projected_pose3d), ord=1, axis=1)
+            # Assign invalid index's reprojection error to be -1
+            reprojection_error[invalid_index] = -1
+            # Append result
+            reprojection_errors[time_stamp][camera_name] = reprojection_error.reshape(-1,1)
 
+    # Save pose3d kpts result
     with open(
         os.path.join(pose3d_dir, f"egoexo_pose3d_triThresh={tri_threshold}.pkl"), "wb"
     ) as f:
         pickle.dump(poses3d, f)
+        # Save reprojection errors
+    with open(os.path.join(pose3d_dir, f"egoexo_pose3d_triThresh={tri_threshold}_reprojection_error.pkl"), "wb"
+    ) as f:
+        pickle.dump(reprojection_errors, f)
 
 
 # ----------- New pipeline's code end ----------- #

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -1166,7 +1166,7 @@ def mode_wholebodyHand_pose3d(config: Config):
 
         # visualize pose3d
         if visualization:
-            for exo_camera_name in exo_cam_names:
+            for exo_camera_name in ctx.exo_cam_names:
                 image_path = info[f"{exo_camera_name}_0"]["abs_frame_path"]
                 image = cv2.imread(image_path)
                 exo_camera = exo_cameras[exo_camera_name]
@@ -1642,7 +1642,7 @@ def mode_exo_hand_pose3d(config: Config):
 
         # visualize pose3d
         if visualization:
-            for camera_name in exo_cam_names:
+            for camera_name in ctx.exo_cam_names:
                 image_path = info[f"{camera_name}_0"]["abs_frame_path"]
                 image = cv2.imread(image_path)
                 curr_camera = exo_cameras[camera_name]
@@ -1827,7 +1827,7 @@ def mode_egoexo_hand_pose3d(config: Config):
         # visualize pose3d
         if visualization:
             ### Exo camera visualization ###
-            for camera_name in exo_cam_names:
+            for camera_name in ctx.exo_cam_names:
                 image_path = info[f"{camera_name}_0"]["abs_frame_path"]
                 image = cv2.imread(image_path)
                 curr_camera = aria_exo_cameras[camera_name]


### PR DESCRIPTION
Major updates:
1. In `hand_pose3d_exo` and `hand_pose3d_egoexo` mode, there will be one more reprojection error pickle file saved along with the 3D hand keypoints, which includes the L1 norm between re-projected and detected hand pose2d keypoints in each camera view.
2. When checking for RANSAC inliers in `triangulator.py`, enables the option to not only rely on number of inliers but also average reprojection error to choose the best two views for triangulation.

Other updates:
1. Enable hand pose2d estimation for a list of ego cameras in `hand_pose2d_ego` mode
2. Check for negative camera z-coordinate when re-projecting wholebody-hand keypoints onto ego (aria) camera plane in `hand_pose2d_ego` mode
3. Fix & optimize code used to find hand bounding boxes from re-projected wholebody-hand keypoints in `hand_pose2d_ego` mode
4. Simplify saving visualization code in `hand_pose3d_egoexo` mode