### PR TITLE
Support frame sampling

### DIFF
--- a/ego4d/internal/human_pose/config.py
+++ b/ego4d/internal/human_pose/config.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Optional
 class Input:
     from_frame_number: int
     to_frame_number: int
+    sample_interval: int
+    subclip_json_dir: Optional[str]
     take_name: Optional[str]
     take_uid: Optional[str]
     capture_root_dir: Optional[str]

--- a/ego4d/internal/human_pose/configs/dev_release_base.yaml
+++ b/ego4d/internal/human_pose/configs/dev_release_base.yaml
@@ -7,6 +7,8 @@ mode: "preprocess"
 inputs:
   from_frame_number: 0
   to_frame_number: null
+  sample_interval: 1
+  subclip_json_dir: null
   take_name: "uniandes_dance_007_3"
   take_uid: null
   metadata_json_path: null

--- a/ego4d/internal/human_pose/undistort_to_halo.py
+++ b/ego4d/internal/human_pose/undistort_to_halo.py
@@ -24,7 +24,7 @@ body_keypoints_list = [
     {"label": "Left-knee", "id": "yz012345", "color": "#83f483"},
     {"label": "Right-knee", "id": "6bc7defg", "color": "#32d58c"},
     {"label": "Left-ankle", "id": "hijk8lmn", "color": "#3ba3ec"},
-    {"label": "Left-ankle", "id": "opqrs1tu", "color": "#f564d4"},
+    {"label": "Right-ankle", "id": "opqrs1tu", "color": "#f564d4"},
 ]
 
 hand_keypoints_list = [
@@ -264,6 +264,12 @@ def undistort_exocam(image_path, intrinsics, distortion_coeffs, dimension=(3840,
     image = cv2.imread(image_path)
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     dim1 = image.shape[:2][::-1]  # dim1 is the dimension of input image to un-distort
+
+    # Change the calibration dim dynamically
+    # (e.g., bouldering cam01 and cam04 are verticall)
+    if DIM[0] != dim1[0]:
+        DIM = (DIM[1], DIM[0])
+
     assert (
         dim1[0] / dim1[1] == DIM[0] / DIM[1]
     ), "Image to undistort needs to have same aspect ratio as the ones used in calibration"


### PR DESCRIPTION
Summary:
- Support frame sampling in 2 ways which are combinable: (1) using Shan's clip selection (by specifying `inputs.subclip_json_dir`; (2) sample every n frames (by specifying `inputs.sample_interval`)
- Sometimes the exo cameras are not all on the ground, so using get_exo_camera_plane is problematic. Use [0, 0, 1] instead.
- Print out running time for each step
- Allow vertical cameras for bouldering cameras (thanks fujenchu)

Differential Revision: D48451711

