### PR TITLE
Avoid crashing in hand pose2d&pose3d estimation when hand is invisible

### DIFF
--- a/ego4d/internal/human_pose/utils.py
+++ b/ego4d/internal/human_pose/utils.py
@@ -370,24 +370,27 @@ def normalize_reprojection_error(reproj_error, bboxes, skel_type):
             # Normalize reprojection error
             if skel_type == "hand":
                 curr_right_bbox, curr_left_bbox = bboxes[ts][cam]
-                # Caculate left and right hand's bbox area
-                right_hand_bbox_area = (curr_right_bbox[2] - curr_right_bbox[0]) * (
-                    curr_right_bbox[3] - curr_right_bbox[1]
-                )
-                left_hand_bbox_area = (curr_left_bbox[2] - curr_left_bbox[0]) * (
-                    curr_left_bbox[3] - curr_left_bbox[1]
-                )
-                # Normalize reprojection error with corresponding hand bbox
-                curr_reproj_error[:21] /= (
-                    right_hand_bbox_area
-                    if right_hand_bbox_area != 0
-                    else curr_reproj_error[:21]
-                )
-                curr_reproj_error[21:] /= (
-                    left_hand_bbox_area
-                    if left_hand_bbox_area != 0
-                    else curr_reproj_error[:21]
-                )
+                # If bbox is None then don't normalize reprojection error
+                if curr_right_bbox is not None:
+                    # Caculate left and right hand's bbox area
+                    right_hand_bbox_area = (curr_right_bbox[2] - curr_right_bbox[0]) * (
+                        curr_right_bbox[3] - curr_right_bbox[1]
+                    )
+                    # Normalize reprojection error with corresponding hand bbox
+                    curr_reproj_error[:21] /= (
+                        right_hand_bbox_area
+                        if right_hand_bbox_area != 0
+                        else curr_reproj_error[:21]
+                    )
+                if curr_left_bbox is not None:
+                    left_hand_bbox_area = (curr_left_bbox[2] - curr_left_bbox[0]) * (
+                        curr_left_bbox[3] - curr_left_bbox[1]
+                    )
+                    curr_reproj_error[21:] /= (
+                        left_hand_bbox_area
+                        if left_hand_bbox_area != 0
+                        else curr_reproj_error[:21]
+                    )
             elif skel_type == "body":
                 # Calculate body bbox area
                 curr_body_bbox = bboxes[ts][cam]


### PR DESCRIPTION
Summary:

* Bug fixed:
    * Propose camera plane normal as [0,0,1] instead of based on camera position in mode=`body_bbox` as in #237 
    * Fix error in mode=`body_bbox` when choosing not visualize results (`visualization=False`)
* New update:
    * In hand pose2d estimation (mode=`hand_pose2d_exo`, `hand_pose2d_ego`), assign None as bbox and pose2d results when hand is invisible in current view
    * In hand pose3d estimation (mode=`hand_pose3d_exo`, `hand_pose3d_egoexo`), cases when hand is invisible are handled to avoid crashing in triangulation; reprojection error calculation is also updated to account for invisible hand cases to avoid crashing