### PR TITLE
Support hand video rendering and reduce storage

### DIFF
--- a/ego4d/internal/human_pose/config.py
+++ b/ego4d/internal/human_pose/config.py
@@ -19,6 +19,16 @@ class Input:
 
 
 @dataclass
+class Output:
+    # storage_level:
+    # 0 is minimum storage, meaning most stuff shall be cleaned up after the job is done
+    # at the cost of losing debugging information;
+    # the higher the level is, the more disk storage we are allow to use
+    # (e.g., for debugging purpose)
+    storage_level: int
+
+
+@dataclass
 class PreprocessFrameConfig:
     dataset_name: str
     vrs_bin_path: str
@@ -60,6 +70,7 @@ class Config:
     gpu_id: int  # use -1 for CPU
     mode: str
     inputs: Input
+    outputs: Output
     mode_preprocess: PreprocessFrameConfig
     mode_bbox: BBoxConfig
     mode_pose2d: PoseEstimationConfig

--- a/ego4d/internal/human_pose/configs/dev_release_base.yaml
+++ b/ego4d/internal/human_pose/configs/dev_release_base.yaml
@@ -19,6 +19,8 @@ inputs:
     - slam-left
     - slam-right
   exo_timesync_name_to_calib_name: null
+outputs:
+  storage_level: 30
 mode_preprocess:
   dataset_name: "dataset"
   vrs_bin_path: "vrs"


### PR DESCRIPTION
Summary:
- Add `outputs.storage_level` option so that we can adjust the storage footprint. The lower this level is, the fewer debugging information we keep on disk (mainly the rendered images), but the less storage we take. Note that the main cleanup happens in the multiview visualization function so you will need to call the visualization steps to enable the cleanup.
- Remove legacy functions `mode_bbox` and `mode_pose2d` as they are not used for a while and could be confusing
- Support hand video rendering, including `hand_wholebodyhand.mp4`, `hand_pose3d.mp4` and `hand_pose2d.mp4`, under modes `vis_hand_wholebodyhand_pose3d`, `vis_hand_pose2d`, and `vis_hand_pose3d`, respectively. As mentioned above, when `outputs.storage_level` is less than or equal to 30/50, these visualization functions will trigger different levels of cleanup.
- As a data point, the storage usage is shrunk by `75%` with `outputs.storage_level`=30

Differential Revision: D49114426


