### PR TITLE
Support min clips length; add script to copy from s3 to manifold

### DIFF
--- a/ego4d/internal/human_pose/config.py
+++ b/ego4d/internal/human_pose/config.py
@@ -8,6 +8,13 @@ class Input:
     to_frame_number: int
     sample_interval: int
     subclip_json_dir: Optional[str]
+    # min_subclip_length:
+    # example: suppose min_subclip_length=120 (unit: frames) and subclip=[30, 80],
+    # it will extend the subclip to [30, 150]. This could be useful for some actions
+    # that take more than 2 seconds (60 frames) so that we sample sufficient frames
+    # for the action.
+    # see function `calculate_frame_selection` for how it's used
+    min_subclip_length: int
     take_name: Optional[str]
     take_uid: Optional[str]
     capture_root_dir: Optional[str]

--- a/ego4d/internal/human_pose/configs/dev_release_base.yaml
+++ b/ego4d/internal/human_pose/configs/dev_release_base.yaml
@@ -9,6 +9,7 @@ inputs:
   to_frame_number: null
   sample_interval: 1
   subclip_json_dir: null
+  min_subclip_length: 120
   take_name: "uniandes_dance_007_3"
   take_uid: null
   metadata_json_path: null

--- a/ego4d/internal/human_pose/main.py
+++ b/ego4d/internal/human_pose/main.py
@@ -1998,7 +1998,9 @@ def mode_preprocess_legacy(config: Config):
     json.dump(dataset_json, open(ctx.dataset_json_path, "w"))
 
 
-def calculate_frame_selection(subclip_json_path, start_frame, end_frame):
+def calculate_frame_selection(
+    subclip_json_path, start_frame, end_frame, min_subclip_length
+):
     frame_selection = [1 for k in range(start_frame, end_frame)]
 
     if subclip_json_path is None:
@@ -2017,7 +2019,10 @@ def calculate_frame_selection(subclip_json_path, start_frame, end_frame):
 
     for i in range(len(raw_subclips)):
         left = max(start_frame, raw_subclips[i][0])
-        right = min(end_frame, raw_subclips[i][1] + 1)
+        right = min(
+            end_frame,
+            max(raw_subclips[i][0] + min_subclip_length + 1, raw_subclips[i][1] + 1),
+        )
         for k in range(left, right):
             frame_selection[k - start_frame] = 1
 
@@ -2065,7 +2070,7 @@ def mode_preprocess(config: Config):
         subclip_json_path = None
 
     frame_selection = calculate_frame_selection(
-        subclip_json_path, start_frame, end_frame
+        subclip_json_path, start_frame, end_frame, config.inputs.min_subclip_length
     )
 
     frame_paths = {}

--- a/ego4d/internal/human_pose/scripts/copy_s3_to_manifold.sh
+++ b/ego4d/internal/human_pose/scripts/copy_s3_to_manifold.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script is supposed to run on devserver
+
+data=$1
+
+aws_date=$2
+# date=20230910
+date=$2
+
+# queue=pilot
+queue=production
+
+manifold mkdir "ego4d_fair/tree/egoexo/egopose/${queue}/${date}"
+manifold mkdir "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}"
+
+set -e
+
+export https_proxy=fwdproxy:8080
+aws s3 sync "s3://ego4d-fair/egopose/${queue}/${aws_date}/${data}" ~/egopose/"${queue}/${date}/${data}"
+
+manifold putr --ignoreExisting -j 10 --threads 1 ~/egopose/"${queue}/${date}/${data}/body" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/body"
+
+manifold putr --ignoreExisting -j 10 --threads 1 ~/egopose/"${queue}/${date}/${data}/hand" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/hand"
+
+rm -rf ~/egopose/"${queue}/${date}/${data}/body"
+rm -rf ~/egopose/"${queue}/${date}/${data}/hand"
+
+manifold put ~/egopose/"${queue}/${date}/${data}/body_bbox.mp4" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/body_bbox.mp4"
+manifold put ~/egopose/"${queue}/${date}/${data}/body_pose2d.mp4" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/body_pose2d.mp4"
+manifold put ~/egopose/"${queue}/${date}/${data}/body_pose3d.mp4" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/body_pose3d.mp4"
+manifold put ~/egopose/"${queue}/${date}/${data}/hand_pose2d.mp4" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/hand_pose2d.mp4"
+manifold put ~/egopose/"${queue}/${date}/${data}/hand_pose3d.mp4" "ego4d_fair/tree/egoexo/egopose/${queue}/${date}/${data}/hand_pose3d.mp4"

--- a/ego4d/internal/human_pose/scripts/upload_s3.sh
+++ b/ego4d/internal/human_pose/scripts/upload_s3.sh
@@ -2,15 +2,19 @@
 
 data=$1
 
-date=20230831
+# date=20230910
+date=$2
 
 # queue=pilot
 queue=production
 
 set -e
 
-aws s3 sync "/checkpoint/${USER}/datasets/EgoExoPose/tmp_0_80000_1/cache/${data}/body/halo" "s3://ego4d-fair/egopose/${queue}/${date}/${data}/body"
+# cache_root_dir="/checkpoint/${USER}/datasets/EgoExoPose/tmp_0_80000_1"
+cache_root_dir="/large_experiments/egoexo/egopose/${USER}/tmp_0_80000_1"
 
-aws s3 sync "/checkpoint/${USER}/datasets/EgoExoPose/tmp_0_80000_1/cache/${data}/hand/halo" "s3://ego4d-fair/egopose/${queue}/${date}/${data}/hand"
+aws s3 sync "${cache_root_dir}/cache/${data}/body/halo" "s3://ego4d-fair/egopose/${queue}/${date}/${data}/body"
 
-aws s3 sync "/checkpoint/${USER}/datasets/EgoExoPose/tmp_0_80000_1/cache/${data}/vis_pose3d" "s3://ego4d-fair/egopose/${queue}/${date}/${data}"
+aws s3 sync "${cache_root_dir}/cache/${data}/hand/halo" "s3://ego4d-fair/egopose/${queue}/${date}/${data}/hand"
+
+aws s3 sync "${cache_root_dir}/cache/${data}/vis_pose3d" "s3://ego4d-fair/egopose/${queue}/${date}/${data}"


### PR DESCRIPTION
Summary:
- Support `inputs.min_subclip_length` option. Example: suppose min_subclip_length=120 (unit: frames) and subclip=[30, 80], it will extend the subclip to [30, 150]. This could be useful for some actions that take more than 2 seconds (60 frames) so that we sample sufficient frames for the action. See function `calculate_frame_selection` for how it's used.
- Add script to copy from s3 to manifold

Differential Revision: D49136805


