### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ boto3
 regex
 iopath
 dataclasses_json
+pycocotools
 av==9.0.2
 einops==0.4.1
 numpy==1.22.3


### PR DESCRIPTION
The repository expects to have `pycocotools` installed but it's not part of the requirements:

```
ego4d/research/util/masks.py", line 6, in <module>
    from pycocotools import mask as mask_utils
ModuleNotFoundError: No module named 'pycocotools'
```

Happens if you run things like this:

```
from ego4d.research.readers import PyAvReader, TorchAudioStreamReader                                
from ego4d.research.util.masks import blend_mask, decode_mask 
```