### PR TITLE
[Ego-Exo4D] Improve CLI Download Performance

### DIFF
--- a/ego4d/internal/download/manifest.py
+++ b/ego4d/internal/download/manifest.py
@@ -19,7 +19,7 @@ class PathSpecification:
         default_factory=lambda: None, compare=False, hash=False
     )
     size: Optional[int] = field(default_factory=lambda: None, compare=False, hash=False)
-    checksum: Optional[int] = field(
+    checksum: Optional[str] = field(
         default_factory=lambda: None, compare=False, hash=False
     )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="ego4d",
-    version="1.7.0",
+    version="1.7.1",
     author="FAIR",
     author_email="info@ego4d-data.org",
     description="Ego4D Dataset CLI",


### PR DESCRIPTION
Previously to download the entire dataset it took 50mins before the CLI could start a download. This improves that time to ~2.5mins (20x speedup) by pre-caching the file sizes in the manifest generation step.

I also:
- enabled `--parts all` and `--parts default` to easily download the entire dataset
- improved the performance of manifest generation.