### PR TITLE
fix #334

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="ego4d",
-    version="1.7.2",
+    version="1.7.3",
     author="FAIR",
     author_email="info@ego4d-data.org",
     description="Ego4D Dataset CLI",


### PR DESCRIPTION
was not loading all benchmark names prior to spitting out error

+ don't sys.exit, just spit out warning and proceed with download (which needs to be confirmed)